### PR TITLE
Use input_id to track inputs being accessed

### DIFF
--- a/validmind/client.py
+++ b/validmind/client.py
@@ -134,7 +134,10 @@ def init_dataset(
             type="dataset",
             metadata=get_dataset_info(vm_dataset),
         )
+
     input_registry.add(key=obj_key, obj=vm_dataset)
+    vm_dataset.input_id = obj_key
+
     return vm_dataset
 
 
@@ -187,7 +190,9 @@ def init_model(
             type="model",
             metadata=get_model_info(vm_model),
         )
+
     input_registry.add(key=obj_key, obj=vm_model)
+    vm_model.input_id = obj_key
 
     return vm_model
 

--- a/validmind/vm_models/dataset.py
+++ b/validmind/vm_models/dataset.py
@@ -24,6 +24,8 @@ class VMDataset(ABC):
     Abstract base class for VM datasets.
     """
 
+    input_id: str = None
+
     @property
     @abstractmethod
     def raw_dataset(self):

--- a/validmind/vm_models/model.py
+++ b/validmind/vm_models/model.py
@@ -61,6 +61,8 @@ class VMModel:
         device_type(str, optional) The device where model is trained
     """
 
+    input_id: str = None
+
     def __init__(
         self,
         model: object = None,

--- a/validmind/vm_models/test_context.py
+++ b/validmind/vm_models/test_context.py
@@ -83,7 +83,7 @@ class TestInput:
     def __init__(self, inputs):
         """Initialize with either a dictionary of inputs"""
         for key, value in inputs.items():
-            # retrieve input object from input registry if input_id is provide
+            # retrieve input object from input registry if input_id is provided
             if isinstance(value, str):
                 value = input_registry.get(key=value)
             setattr(self, key, value)
@@ -110,7 +110,8 @@ class InputAccessTrackerProxy:
     def __getattr__(self, name):
         # Track access only if the attribute actually exists in the inputs
         if hasattr(self._inputs, name):
-            self._accessed.add(name)
+            input = getattr(self._inputs, name)
+            self._accessed.add(input.input_id)
             return getattr(self._inputs, name)
 
         raise AttributeError(


### PR DESCRIPTION
## Internal Notes for Reviewers

- Fixes a bug where input metadata was not tracked correctly due to not relying on `input_id` for looking up inputs

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->