### PR TITLE
Update release_notes_check.yamlRun release notes check only if not in draft mode

### DIFF
--- a/.github/workflows/release_notes_check.yaml
+++ b/.github/workflows/release_notes_check.yaml
@@ -2,7 +2,7 @@ name: Release notes check
 
 on:
   pull_request:
-    types: [opened, synchronize, labeled, unlabeled, edited]
+    types: [opened, synchronize, labeled, unlabeled, edited, ready_for_review]
 
 jobs:
   ci_check:

--- a/.github/workflows/release_notes_check.yaml
+++ b/.github/workflows/release_notes_check.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   ci_check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR makes a small tweak to our release notes check so that it runs only if a PR is not in draft mode. This should avoid frequent CI check failures when a PR is in progress.

Screenshot of show how this works in https://github.com/validmind/documentation/pull/159

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->