### PR TITLE
Support adding new extra columns on the fly

### DIFF
--- a/validmind/unit_metrics/composite.py
+++ b/validmind/unit_metrics/composite.py
@@ -5,6 +5,7 @@
 import ast
 import inspect
 from dataclasses import dataclass
+from typing import List
 from uuid import uuid4
 
 from ..utils import clean_docstring, run_async, test_id_to_name
@@ -69,7 +70,7 @@ def _extract_required_inputs(cls):
 @dataclass
 class CompositeMetric(Metric):
 
-    unit_metrics: list[str] = None
+    unit_metrics: List[str] = None
 
     def __post_init__(self):
         if self._unit_metrics:
@@ -100,7 +101,7 @@ class CompositeMetric(Metric):
 def load_composite_metric(
     test_id: str = None,
     metric_name: str = None,
-    unit_metrics: list[str] = None,
+    unit_metrics: List[str] = None,
     output_template: str = None,
 ) -> CompositeMetric:
     # this function can either create a composite metric from a list of unit metrics or
@@ -146,7 +147,7 @@ def load_composite_metric(
 
 def run_metrics(
     name: str = None,
-    metric_ids: list[str] = None,
+    metric_ids: List[str] = None,
     description: str = None,
     output_template: str = None,
     inputs: dict = None,

--- a/validmind/vm_models/test/result_wrapper.py
+++ b/validmind/vm_models/test/result_wrapper.py
@@ -10,7 +10,7 @@ import json
 import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Dict, List, Optional, Union
 
 import ipywidgets as widgets
 import markdown
@@ -26,7 +26,7 @@ from .result_summary import ResultSummary
 from .threshold_test_result import ThresholdTestResults
 
 
-async def update_metadata(content_id: str, text: str, _json: dict | list = None):
+async def update_metadata(content_id: str, text: str, _json: Union[Dict, List] = None):
     """
     Update the metadata of a content item. By default we don't
     override the existing metadata, but we can override it by


### PR DESCRIPTION
## Internal Notes for Reviewers

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

- Added support for two new VMDataset methods: `add_extra_column()` and `get_extra_column()`

### add_extra_column()

You can now register arbitrary extra columns in a dataset when a test needs to compute metrics outside of the existing (features, targets, predictions) sets of columns. An example of this is when credit risk related metrics require access to a list of scores computed from predictions. In this case there needs to be an extra column called `scores` that is used for computing the metrics.

Example usage:

```python
# Init your dataset as usual
vm_train_ds = vm.init_dataset(
    dataset=train_df,
    input_id="train_dataset",
    target_column=customer_churn.target_column,
)

# Generate scores using a user defined function:
scores = compute_my_scores(x_train)

# Assign a new "scores" column to vm_train_ds:
vm_train_ds.add_extra_column("scores", scores)
```

This function will throw an error if no column values are passed:

```python
vm_train_ds.add_extra_column("scores")

ValueError: Column values must be provided when the column doesn't exist in the dataset
```

It's also possible to use `init_dataset` with a dataset that has precomputed scores, i.e.:

```
> train_df.columns
Index(['CreditScore', 'Gender', 'Age', 'Tenure', 'Balance', 'NumOfProducts',
       'HasCrCard', 'IsActiveMember', 'EstimatedSalary', 'Exited',
       'Geography_France', 'Geography_Germany', 'Geography_Spain'],
      dtype='object')
```

```
> train_df["my_scores"] = scores
> train_df.columns
Index(['CreditScore', 'Gender', 'Age', 'Tenure', 'Balance', 'NumOfProducts',
       'HasCrCard', 'IsActiveMember', 'EstimatedSalary', 'Exited',
       'Geography_France', 'Geography_Germany', 'Geography_Spain',
       'my_scores'],
      dtype='object')
```

Make sure you set the `feature_columns` properly:

```python
vm_train_ds = vm.init_dataset(
    dataset=train_df,
    input_id="another_ds",
    feature_columns=[
        "CreditScore",
        "Gender",
        "Age",
        "Tenure",
        "Balance",
        "NumOfProducts",
        "HasCrCard",
        "IsActiveMember",
        "EstimatedSalary",
        "Exited",
        "Geography_France",
        "Geography_Germany",
        "Geography_Spain",
    ],
    target_column=customer_churn.target_column,
)
```

Then, call `add_extra_column()` to register the extra column:

```
> another_ds.add_extra_column(column_name="my_scores")
Column my_scores exists in the dataset, registering as an extra column
```


### get_extra_column()

You can use this inside a test to retrieve the extra column values. Example:

```python
scores = self.inputs.dataset.get_extra_column("scores")
```