### PR TITLE
Hotfix for Integration Tests Script

### DIFF
--- a/scripts/run_e2e_notebooks.py
+++ b/scripts/run_e2e_notebooks.py
@@ -128,7 +128,10 @@ def update_vm_init_cell(notebook_path, project_id):
 
     for cell in nb["cells"]:
         if cell["cell_type"] == "code":
-            if "import validmind as vm" in cell["source"]:
+            if (
+                "import validmind as vm" in cell["source"]
+                and "vm.init(" in cell["source"]
+            ):
                 cell["source"] = init_code
 
     with open(notebook_path, "w") as f:

--- a/scripts/run_e2e_notebooks.py
+++ b/scripts/run_e2e_notebooks.py
@@ -24,6 +24,7 @@ This uses the dev environment for now... In the future, we may want to change th
 """
 
 import os
+import re
 
 import click
 import dotenv
@@ -127,12 +128,11 @@ def update_vm_init_cell(notebook_path, project_id):
         nb = nbformat.read(f, as_version=4)
 
     for cell in nb["cells"]:
-        if cell["cell_type"] == "code":
-            if (
-                "import validmind as vm" in cell["source"]
-                and "vm.init(" in cell["source"]
-            ):
-                cell["source"] = init_code
+        if cell["cell_type"] == "code" and "vm.init(" in cell["source"]:
+            # replace any existing vm.init() calls with the new one
+            cell["source"] = re.sub(
+                r"vm.init\(.+\)", init_code, cell["source"], flags=re.DOTALL
+            )
 
     with open(notebook_path, "w") as f:
         nbformat.write(nb, f)


### PR DESCRIPTION
## Internal Notes for Reviewers

The integration tests started failing after my latest merge. Turns out the code that replaces existing `vm.init` cells with a version that points to the project/endpoint for the integration tests was simply looking for `import validmind as vm` in each cell and replacing the whole cell if it had that import. This did not work for the new notebooks I added to the integration tests script so I updated to use `re.sub` to directly swap `vm.init` calls.

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->