### PR TITLE
Support for external models

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -108,17 +108,22 @@ class TestInitModel(TestCase):
         vm_model = init_model(model)
         self.assertEqual(vm_model.model, model)
 
-    @mock.patch(
-        "validmind.client.log_input",
-        return_value="1234",
-    )
-    def test_init_model_metadata_dict(self, mock_log_input):
+    def test_init_model_invalid_metadata_dict(self):
+        # Model metadata requires architecture and language at a minimum
+        metadata = {
+            "key": "value",
+            "foo": "bar",
+        }
+        with self.assertRaises(UnsupportedModelError) as context:
+            init_model(attributes=metadata, __log=False)
+
+    def test_init_model_metadata_dict(self):
         # Model metadata requires architecture and language at a minimum
         metadata = {
             "architecture": "Spark",
             "language": "Python",
         }
-        vm_model = init_model(attributes=metadata)
+        vm_model = init_model(attributes=metadata, __log=False)
 
         # Model will be none but attributes will be populated
         self.assertEqual(vm_model.attributes.architecture, metadata["architecture"])

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,6 +17,7 @@ from validmind import (
     get_test_suite,
     run_documentation_tests,
 )
+from validmind.errors import UnsupportedModelError
 
 
 @dataclass
@@ -92,15 +93,36 @@ class TestInitDataset(TestCase):
 
 
 class TestInitModel(TestCase):
+    def test_init_model_invalid_model(self):
+        model = dict()
+        with self.assertRaises(UnsupportedModelError):
+            init_model(model)
+
     @mock.patch(
         "validmind.client.log_input",
         return_value="1234",
     )
-    def test_init_model(self, mock_log_input):
+    def test_init_model_supported_model(self, mock_log_input):
         # Test initializing an SKLearn model
         model = sklearn.linear_model.LinearRegression()
         vm_model = init_model(model)
         self.assertEqual(vm_model.model, model)
+
+    @mock.patch(
+        "validmind.client.log_input",
+        return_value="1234",
+    )
+    def test_init_model_metadata_dict(self, mock_log_input):
+        # Model metadata requires architecture and language at a minimum
+        metadata = {
+            "architecture": "Spark",
+            "language": "Python",
+        }
+        vm_model = init_model(attributes=metadata)
+
+        # Model will be none but attributes will be populated
+        self.assertEqual(vm_model.attributes.architecture, metadata["architecture"])
+        self.assertEqual(vm_model.attributes.language, metadata["language"])
 
 
 # Run methods are tested in test_full_suite_nb.py and test_full_suite.py

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -3,12 +3,17 @@ Unit tests for VMDataset class
 """
 
 import unittest
-from unittest import mock, TestCase
+from unittest import TestCase
 
 import pandas as pd
 import numpy as np
 
+from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.ensemble import RandomForestClassifier
+
+from validmind.client import init_model
 from validmind.vm_models.dataset import DataFrameDataset
+from validmind.vm_models.model import ModelAttributes, VMModel
 
 
 class TestTabularDataset(TestCase):
@@ -22,7 +27,7 @@ class TestTabularDataset(TestCase):
 
     def test_init_dataset_pandas_no_options(self):
         """
-        Assert that a DataFrameDataset can be initialized with a pandas DataFrame and no options
+        Test that a DataFrameDataset can be initialized with a pandas DataFrame and no options
         """
         vm_dataset = DataFrameDataset(raw_dataset=self.df)
 
@@ -32,7 +37,7 @@ class TestTabularDataset(TestCase):
 
     def test_init_dataset_pandas_target_column(self):
         """
-        Assert that a DataFrameDataset provides access to the target column
+        Test that a DataFrameDataset provides access to the target column
         """
         vm_dataset = DataFrameDataset(raw_dataset=self.df, target_column="target")
 
@@ -47,7 +52,7 @@ class TestTabularDataset(TestCase):
 
     def test_init_dataset_pandas_feature_columns(self):
         """
-        Assert that a DataFrameDataset allows configuring feature columns
+        Test that a DataFrameDataset allows configuring feature columns
         """
         vm_dataset = DataFrameDataset(
             raw_dataset=self.df, target_column="target", feature_columns=["col1"]
@@ -59,6 +64,144 @@ class TestTabularDataset(TestCase):
         self.assertEquals(vm_dataset.get_numeric_features_columns(), ["col1"])
         self.assertEquals(vm_dataset.get_categorical_features_columns(), [])
         self.assertEquals(vm_dataset.feature_columns, ["col1"])
+
+    def test_assign_predictions_invalid_model(self):
+        """
+        Test assigning predictions to dataset with an invalid model
+        """
+        vm_dataset = DataFrameDataset(
+            raw_dataset=self.df, target_column="target", feature_columns=["col1"]
+        )
+
+        vm_model = dict()
+        with self.assertRaises(ValueError, msg="Model must be a VMModel instance"):
+            vm_dataset.assign_predictions(model=vm_model)
+
+        # If a user initializes a VMModel with no underlying model or passes attributes only
+        vm_model = VMModel(input_id="1234")
+        with self.assertRaises(
+            AttributeError, msg="VMModel must have a valid predict method"
+        ):
+            vm_dataset.assign_predictions(model=vm_model)
+
+        vm_model = VMModel(
+            input_id="1234",
+            attributes=ModelAttributes.from_dict(
+                {
+                    "architecture": "Spark",
+                    "language": "Python",
+                }
+            ),
+        )
+        with self.assertRaises(
+            AttributeError, msg="VMModel must have a valid predict method"
+        ):
+            vm_dataset.assign_predictions(model=vm_model)
+
+    def test_assign_predictions_with_classification_model(self):
+        """
+        Test assigning predictions to dataset with a valid model
+        """
+        df = pd.DataFrame({"x1": [1, 2, 3], "x2": [4, 5, 6], "y": [0, 1, 0]})
+        vm_dataset = DataFrameDataset(
+            raw_dataset=df, target_column="y", feature_columns=["x1", "x2"]
+        )
+
+        # Train a simple model
+        model = LogisticRegression()
+        model.fit(vm_dataset.x, vm_dataset.y.ravel())
+
+        vm_model = init_model(input_id="logreg", model=model, __log=False)
+        with self.assertRaises(
+            ValueError, msg="Prediction column is not linked with the given logreg"
+        ):
+            vm_dataset.prediction_column(vm_model)
+
+        vm_dataset.assign_predictions(model=vm_model)
+        self.assertEquals(vm_dataset.prediction_column(vm_model), "logreg_prediction")
+
+        # Check that the predictions are assigned to the dataset
+        self.assertTrue("logreg_prediction" in vm_dataset.df.columns)
+        self.assertIsInstance(vm_dataset.y_pred(vm_model), np.ndarray)
+        self.assertIsInstance(vm_dataset.y_pred_df(vm_model), pd.Series)
+
+        # This model in particular will calculate probabilities as well
+        self.assertTrue("logreg_probabilities" in vm_dataset.df.columns)
+        self.assertIsInstance(vm_dataset.y_prob(vm_model), np.ndarray)
+        self.assertIsInstance(vm_dataset.y_prob_df(vm_model), pd.Series)
+
+    def test_assign_predictions_with_regression_model(self):
+        """
+        Test assigning predictions to dataset with a valid model
+        """
+        df = pd.DataFrame({"x1": [1, 2, 3], "x2": [4, 5, 6], "y": [0.1, 1.2, 2.3]})
+        vm_dataset = DataFrameDataset(
+            raw_dataset=df, target_column="y", feature_columns=["x1", "x2"]
+        )
+
+        # Train a simple model
+        model = LinearRegression()
+        model.fit(vm_dataset.x, vm_dataset.y.ravel())
+
+        vm_model = init_model(input_id="linreg", model=model, __log=False)
+        with self.assertRaises(
+            ValueError, msg="Prediction column is not linked with the given linreg"
+        ):
+            vm_dataset.prediction_column(vm_model)
+
+        vm_dataset.assign_predictions(model=vm_model)
+        self.assertEquals(vm_dataset.prediction_column(vm_model), "linreg_prediction")
+
+        # Check that the predictions are assigned to the dataset
+        self.assertTrue("linreg_prediction" in vm_dataset.df.columns)
+        self.assertIsInstance(vm_dataset.y_pred(vm_model), np.ndarray)
+        self.assertIsInstance(vm_dataset.y_pred_df(vm_model), pd.Series)
+
+        # Linear models do not have probabilities
+        self.assertFalse("linreg_probabilities" in vm_dataset.df.columns)
+
+    def test_assign_predictions_with_multiple_models(self):
+        """
+        Test assigning predictions to dataset with a valid model
+        """
+        df = pd.DataFrame({"x1": [1, 2, 3], "x2": [4, 5, 6], "y": [0, 1, 0]})
+        vm_dataset = DataFrameDataset(
+            raw_dataset=df, target_column="y", feature_columns=["x1", "x2"]
+        )
+
+        # Train simple models
+        lr_model = LogisticRegression()
+        lr_model.fit(vm_dataset.x, vm_dataset.y.ravel())
+
+        rf_model = RandomForestClassifier()
+        rf_model.fit(vm_dataset.x, vm_dataset.y.ravel())
+
+        vm_lr_model = init_model(input_id="logreg", model=lr_model, __log=False)
+        vm_rf_model = init_model(input_id="rf", model=rf_model, __log=False)
+
+        vm_dataset.assign_predictions(model=vm_lr_model)
+        vm_dataset.assign_predictions(model=vm_rf_model)
+
+        self.assertEquals(
+            vm_dataset.prediction_column(vm_lr_model), "logreg_prediction"
+        )
+        self.assertEquals(vm_dataset.prediction_column(vm_rf_model), "rf_prediction")
+
+        # Check that the predictions are assigned to the dataset
+        self.assertTrue("logreg_prediction" in vm_dataset.df.columns)
+        self.assertTrue("rf_prediction" in vm_dataset.df.columns)
+        self.assertIsInstance(vm_dataset.y_pred(vm_lr_model), np.ndarray)
+        self.assertIsInstance(vm_dataset.y_pred_df(vm_lr_model), pd.Series)
+        self.assertIsInstance(vm_dataset.y_pred(vm_rf_model), np.ndarray)
+        self.assertIsInstance(vm_dataset.y_pred_df(vm_rf_model), pd.Series)
+
+        # This model in particular will calculate probabilities as well
+        self.assertTrue("logreg_probabilities" in vm_dataset.df.columns)
+        self.assertTrue("rf_probabilities" in vm_dataset.df.columns)
+        self.assertIsInstance(vm_dataset.y_prob(vm_lr_model), np.ndarray)
+        self.assertIsInstance(vm_dataset.y_prob_df(vm_lr_model), pd.Series)
+        self.assertIsInstance(vm_dataset.y_prob(vm_rf_model), np.ndarray)
+        self.assertIsInstance(vm_dataset.y_prob_df(vm_rf_model), pd.Series)
 
 
 if __name__ == "__main__":

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,65 @@
+"""
+Unit tests for VMDataset class
+"""
+
+import unittest
+from unittest import mock, TestCase
+
+import pandas as pd
+import numpy as np
+
+from validmind.vm_models.dataset import DataFrameDataset
+
+
+class TestTabularDataset(TestCase):
+    def setUp(self):
+        """
+        Create a sample dataset for testing
+        """
+        self.df = pd.DataFrame(
+            {"col1": [1, 2, 3], "col2": ["a", "b", "c"], "target": [0, 1, 0]}
+        )
+
+    def test_init_dataset_pandas_no_options(self):
+        """
+        Assert that a DataFrameDataset can be initialized with a pandas DataFrame and no options
+        """
+        vm_dataset = DataFrameDataset(raw_dataset=self.df)
+
+        # Pandas dataframe gets converted to numpy internally and raw_dataset is a numpy array
+        np.testing.assert_array_equal(vm_dataset.raw_dataset, self.df.values)
+        pd.testing.assert_frame_equal(vm_dataset.df, self.df)
+
+    def test_init_dataset_pandas_target_column(self):
+        """
+        Assert that a DataFrameDataset provides access to the target column
+        """
+        vm_dataset = DataFrameDataset(raw_dataset=self.df, target_column="target")
+
+        self.assertEquals(vm_dataset.target_column, "target")
+        np.testing.assert_array_equal(vm_dataset.y, self.df[["target"]].values)
+        pd.testing.assert_series_equal(vm_dataset.y_df(), self.df["target"])
+
+        # Feature columns should be all columns except the target column
+        self.assertEquals(vm_dataset.get_numeric_features_columns(), ["col1"])
+        self.assertEquals(vm_dataset.get_categorical_features_columns(), ["col2"])
+        self.assertEquals(vm_dataset.feature_columns, ["col1", "col2"])
+
+    def test_init_dataset_pandas_feature_columns(self):
+        """
+        Assert that a DataFrameDataset allows configuring feature columns
+        """
+        vm_dataset = DataFrameDataset(
+            raw_dataset=self.df, target_column="target", feature_columns=["col1"]
+        )
+
+        # Only one feature column "col1"
+        np.testing.assert_array_equal(vm_dataset.x, self.df[["col1"]].values)
+
+        self.assertEquals(vm_dataset.get_numeric_features_columns(), ["col1"])
+        self.assertEquals(vm_dataset.get_categorical_features_columns(), [])
+        self.assertEquals(vm_dataset.feature_columns, ["col1"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validmind/client.py
+++ b/validmind/client.py
@@ -205,10 +205,15 @@ def init_model(
         vm.VMModel: A VM Model instance
     """
     class_obj = get_model_class(model=model)
-    if not class_obj and not is_model_metadata(attributes):
-        raise UnsupportedModelError(
-            f"Model class {str(model.__class__)} is not supported at the moment."
-        )
+    if not class_obj:
+        if not attributes:
+            raise UnsupportedModelError(
+                f"Model class {str(model.__class__)} is not supported at the moment."
+            )
+        elif not is_model_metadata(attributes):
+            raise UnsupportedModelError(
+                f"Model attributes {str(attributes)} are missing required keys 'architecture' and 'language'."
+            )
 
     input_id = input_id or "model"
     vm_model = None

--- a/validmind/tests/model_validation/sklearn/SHAPGlobalImportance.py
+++ b/validmind/tests/model_validation/sklearn/SHAPGlobalImportance.py
@@ -176,6 +176,7 @@ class SHAPGlobalImportance(Metric):
                 ),
             )
         else:
+            model_class = "<ExternalModel>" if model_class is None else model_class
             raise UnsupportedModelForSHAPError(
                 f"Model {model_class} not supported for SHAP importance."
             )

--- a/validmind/vm_models/dataset.py
+++ b/validmind/vm_models/dataset.py
@@ -490,7 +490,7 @@ class NumpyDataset(VMDataset):
 
     def assign_predictions(  # noqa: C901 - we need to simplify this method
         self,
-        model,
+        model: VMModel,
         prediction_values: list = None,
         prediction_probabilities: list = None,
         prediction_column=None,
@@ -588,6 +588,16 @@ class NumpyDataset(VMDataset):
             model=model, prediction_column=prediction_column
         ):
 
+            # Ensure the VMModel has a predict method. This should not happen in practice
+            # unless the user is trying to initialize a model with attributes only.
+            if not hasattr(model, "predict"):
+                raise AttributeError(
+                    f"VMModel object does not have a predict method. "
+                    "\nUnable to compute predictions from the model. "
+                    "Please assign predictions directly with "
+                    "vm_dataset.assign_predictions(model, prediction_values)"
+                )
+
             # Compute prediction values directly from the VM model
             pred_column = f"{model.input_id}_prediction"
             if pred_column in self.columns:
@@ -606,6 +616,7 @@ class NumpyDataset(VMDataset):
             )
 
             prediction_values = np.array(model.predict(x_only))
+            print(prediction_values)
 
             # Check if the prediction values are probabilities
             if _is_probability(prediction_values):

--- a/validmind/vm_models/dataset.py
+++ b/validmind/vm_models/dataset.py
@@ -592,7 +592,7 @@ class NumpyDataset(VMDataset):
             # unless the user is trying to initialize a model with attributes only.
             if not hasattr(model, "predict"):
                 raise AttributeError(
-                    f"VMModel object does not have a predict method. "
+                    "VMModel object does not have a predict method. "
                     "\nUnable to compute predictions from the model. "
                     "Please assign predictions directly with "
                     "vm_dataset.assign_predictions(model, prediction_values)"

--- a/validmind/vm_models/dataset.py
+++ b/validmind/vm_models/dataset.py
@@ -542,9 +542,6 @@ class NumpyDataset(VMDataset):
                     UserWarning,
                 )
 
-            logger.info(
-                f"Assigning prediction values to column '{pred_column}' and linked to model '{model.input_id}'"
-            )
             self.__assign_prediction_values(model, pred_column, prediction_values)
 
         # Step 3: Probability Column Provided
@@ -576,9 +573,6 @@ class NumpyDataset(VMDataset):
                     UserWarning,
                 )
 
-            logger.info(
-                f"Assigning prediction probabilities to column '{prob_column}' and linked to model '{model.input_id}'"
-            )
             self.__assign_prediction_probabilities(
                 model, prob_column, prediction_probabilities
             )
@@ -616,7 +610,6 @@ class NumpyDataset(VMDataset):
             )
 
             prediction_values = np.array(model.predict(x_only))
-            print(prediction_values)
 
             # Check if the prediction values are probabilities
             if _is_probability(prediction_values):
@@ -654,10 +647,13 @@ class NumpyDataset(VMDataset):
                     )
                 except MissingOrInvalidModelPredictFnError:
                     # Log that predict_proba is not available or failed
-                    logger.warn(
-                        f"Model class '{model.__class__}' does not have a compatible predict_proba implementation."
-                        + " Please assign predictions directly with vm_dataset.assign_predictions(model, prediction_values)"
-                    )
+                    # TODO: don't log this warning for all models. Linear regression models
+                    # would not have predict_proba
+                    # logger.warn(
+                    #     f"Model class ({model.model.__class__}) '{model.__class__}' does not have a compatible predict_proba implementation."
+                    #     + " Please assign predictions directly with vm_dataset.assign_predictions(model, prediction_values)"
+                    # )
+                    pass
 
         # Step 7: Prediction Column Already Linked
         else:

--- a/validmind/vm_models/model.py
+++ b/validmind/vm_models/model.py
@@ -41,6 +41,19 @@ class ModelAttributes:
     architecture: str = None
     framework: str = None
     framework_version: str = None
+    language: str = None
+
+    @classmethod
+    def from_dict(cls, data):
+        """
+        Creates a ModelAttributes instance from a dictionary
+        """
+        return cls(
+            architecture=data.get("architecture"),
+            framework=data.get("framework"),
+            framework_version=data.get("framework_version"),
+            language=data.get("language"),
+        )
 
 
 class VMModel:
@@ -199,7 +212,7 @@ def get_model_class(model):
     model_class_name = SUPPORTED_LIBRARIES.get(model_module(model), None)
 
     if model_class_name is None:
-        raise Exception("Model library not supported")
+        return None
 
     model_class = getattr(
         importlib.import_module("validmind.models"),
@@ -207,3 +220,23 @@ def get_model_class(model):
     )
 
     return model_class
+
+
+def is_model_metadata(model):
+    """
+    Checks if the model is a dictionary containing metadata about a model.
+    We want to check if the metadata dictionary contains at least the following keys:
+
+    - architecture
+    - language
+    """
+    if not isinstance(model, dict):
+        return False
+
+    if "architecture" not in model:
+        return False
+
+    if "language" not in model:
+        return False
+
+    return True

--- a/validmind/vm_models/model.py
+++ b/validmind/vm_models/model.py
@@ -109,21 +109,6 @@ class VMModel:
         }
 
     @abstractmethod
-    def predict_proba(self, *args, **kwargs):
-        """
-        Predict probability for the model.
-        This is a wrapper around the model's if available
-        """
-        pass
-
-    @abstractmethod
-    def predict(self, *args, **kwargs):
-        """
-        Predict method for the model. This is a wrapper around the model's
-        """
-        pass
-
-    @abstractmethod
     def model_language(self, *args, **kwargs):
         """
         Programming language used to train the model. Assume Python if this


### PR DESCRIPTION
## Internal Notes for Reviewers

- Added unit test coverage to `Dataset` class
- Added support for model `attributes` when initializing a `Model`

## External Release Notes

You can now run documentation tests without passing a Python-native model object. This enables documenting:
- Models that are developed in non-Python environments
- Non-standard model interfaces:
    - Models deployed as APIs, i.e. SageMaker model endpoints
    - Tools such as Spark where a "model"  is not a typical object that exposes a `predict()` interface

To run tests for these models you typically need to load model predictions from a file, dataset, etc. The new `init_model` interface does not enforce a Python model object anymore. You only need to pass `attributes` that describe the model. This is required as a best practice for model documentation.

### Initializing an external model

Since there is no native Python object to pass to `init_model`, you will need to pass attributes that describe the model:

```python
# Assume you want to load predictions for a PySpark ML model
model_attributes = {
    "architecture": "Spark",
    "language": "PySpark",
}

# Or maybe you're loading predictions for a SageMaker endpoint (model API)
model_attributes = {
    "architecture": "SageMaker Model",
    "language": "Python",
}

# Call `init_model` without passing a model. Pass `attributes` instead
vm_model = vm.init_model(
    attributes=model_attributes,
    input_id="model",
)
```

### Assigning predictions

Since there's no model object available, the developer framework won't be able to call `model.predict()` (and `model.predict_proba()` for you. You will need to load predictions (and probabilities) manually, i.e.:

```python
vm_train_ds.assign_predictions(
    model=vm_model,
    prediction_values=prediction_values,
    prediction_probabilities=prediction_probabilities,
)
```

You can run tests as usual. No other changes are needed.