### PR TITLE
QuickStart notebook improvements

### DIFF
--- a/notebooks/code_samples/quickstart_customer_churn_full_suite.ipynb
+++ b/notebooks/code_samples/quickstart_customer_churn_full_suite.ipynb
@@ -1,531 +1,523 @@
 {
   "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Quickstart for model documentation\n",
-        "\n",
-        "Welcome! Let's get you started with the basic process of documenting models with ValidMind.\n",
-        "\n",
-        "You will learn how to initialize the ValidMind Developer Framework, load a sample dataset to train a simple classification model, and then run a ValidMind test suite to quickly generate documentation about the data and model.\n",
-        "\n",
-        "This notebook uses the [Bank Customer Churn Prediction](https://www.kaggle.com/code/kmalit/bank-customer-churn-prediction/data) sample dataset from Kaggle to train the classification model."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc0_'></a>\n",
-        "\n",
-        "## Contents<a id='toc0_'></a>    \n",
-        "- [About ValidMind](#toc1_)    \n",
-        "  - [Before you begin](#toc1_1_)    \n",
-        "  - [New to ValidMind?](#toc1_2_)    \n",
-        "  - [Key concepts](#toc1_3_)    \n",
-        "- [Install the client library](#toc2_)    \n",
-        "- [Initialize the client library](#toc3_)    \n",
-        "- [Initialize the Python environment](#toc4_)    \n",
-        "  - [Preview the documentation template](#toc4_1_)    \n",
-        "- [Load the sample dataset](#toc5_)    \n",
-        "- [Document the model](#toc6_)    \n",
-        "  - [Prepocess the raw dataset](#toc6_1_)    \n",
-        "  - [Initialize the ValidMind datasets](#toc6_2_)    \n",
-        "  - [Initialize a model object](#toc6_3_)    \n",
-        "  - [Assign predictions to the datasets](#toc6_4_)    \n",
-        "  - [Run the full suite of tests](#toc6_5_)    \n",
-        "- [Next steps](#toc7_)    \n",
-        "  - [Work with your model documentation](#toc7_1_)    \n",
-        "  - [Discover more learning resources](#toc7_2_)    \n",
-        "\n",
-        "<!-- vscode-jupyter-toc-config\n",
-        "\tnumbering=false\n",
-        "\tanchor=true\n",
-        "\tflat=false\n",
-        "\tminLevel=2\n",
-        "\tmaxLevel=4\n",
-        "\t/vscode-jupyter-toc-config -->\n",
-        "<!-- THIS CELL WILL BE REPLACED ON TOC UPDATE. DO NOT WRITE YOUR TEXT IN THIS CELL -->"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc1_'></a>\n",
-        "\n",
-        "## <a id='toc1_'></a>About ValidMind [](#toc0_)\n",
-        "\n",
-        "ValidMind is a platform for managing model risk, including risk associated with AI and statistical models.\n\nYou use the ValidMind Developer Framework to automate documentation and validation tests, and then use the ValidMind AI Risk Platform UI to collaborate on model documentation. Together, these products simplify model risk management, facilitate compliance with regulations and institutional standards, and enhance collaboration between yourself and model validators.\n",
-        "\n",
-        "<a id='toc1_1_'></a>\n",
-        "\n",
-        "### <a id='toc1_1_'></a>Before you begin [](#toc0_)\n",
-        "\n",
-        "This notebook assumes you have basic familiarity with Python, including an understanding of how functions work. If you are new to Python, you can still run the notebook but we recommend further familiarizing yourself with the language. \n",
-        "\n",
-        "If you encounter errors due to missing modules in your Python environment, install the modules with `pip install`, and then re-run the notebook. For more help, refer to [Installing Python Modules](https://docs.python.org/3/installing/index.html).\n",
-        "\n",
-        "<a id='toc1_2_'></a>\n",
-        "\n",
-        "### <a id='toc1_2_'></a>New to ValidMind? [](#toc0_)\n",
-        "\n",
-        "If you haven't already seen our [Get started with the ValidMind Developer Framework](https://docs.validmind.ai/guide/get-started-developer-framework.html), we recommend you explore the available resources for developers at some point. There, you can learn more about documenting models, find code samples, or read our developer reference.\n",
-        "\n",
-        "::: {.cell .markdown}\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\">For access to all features available in this notebook, create a free ValidMind account.\n",
-        "\n",
-        "Signing up is FREE — <a href=\"https://app.prod.validmind.ai\">Sign up now</a></div>\n",
-        "\n",
-        ":::\n",
-        "\n",
-        "\n",
-        "::: {.callout-tip}\n",
-        "\n",
-        "For access to all features available in this notebook, create a free ValidMind account.\n",
-        "\n",
-        "Signing up is FREE — [**Sign up now!**](https://app.prod.validmind.ai)\n",
-        "\n",
-        ":::\n",
-        "\n",
-        "<a id='toc1_3_'></a>\n",
-        "\n",
-        "### <a id='toc1_3_'></a>Key concepts [](#toc0_)\n",
-        "\n",
-        "**Model documentation**: A structured and detailed record pertaining to a model, encompassing key components such as its underlying assumptions, methodologies, data sources, inputs, performance metrics, evaluations, limitations, and intended uses. It serves to ensure transparency, adherence to regulatory requirements, and a clear understanding of potential risks associated with the model’s application.\n",
-        "\n",
-        "**Documentation template**: Functions as a test suite and lays out the structure of model documentation, segmented into various sections and sub-sections. Documentation templates define the structure of your model documentation, specifying the tests that should be run, and how the results should be displayed.\n",
-        "\n",
-        "**Tests**: A function contained in the ValidMind Developer Framework, designed to run a specific quantitative test on the dataset or model. Tests are the building blocks of ValidMind, used to evaluate and document models and datasets, and can be run individually or as part of a suite defined by your model documentation template.\n",
-        "\n",
-        "**Metrics**: A subset of tests that do not have thresholds. In the context of this notebook, metrics and tests can be thought of as interchangeable concepts.\n",
-        "\n",
-        "**Custom metrics**: Custom metrics are functions that you define to evaluate your model or dataset. These functions can be registered with ValidMind to be used in the platform.\n",
-        "\n",
-        "**Inputs**: Objects to be evaluated and documented in the ValidMind framework. They can be any of the following:\n",
-        "\n",
-        "  - **model**: A single model that has been initialized in ValidMind with [`vm.init_model()`](https://docs.validmind.ai/validmind/validmind.html#init_model).\n",
-        "  - **dataset**: Single dataset that has been initialized in ValidMind with [`vm.init_dataset()`](https://docs.validmind.ai/validmind/validmind.html#init_dataset).\n",
-        "  - **models**: A list of ValidMind models - usually this is used when you want to compare multiple models in your custom metric.\n",
-        "  - **datasets**: A list of ValidMind datasets - usually this is used when you want to compare multiple datasets in your custom metric. See this [example](https://docs.validmind.ai/notebooks/how_to/run_tests_that_require_multiple_datasets.html) for more information.\n",
-        "\n",
-        "**Parameters**: Additional arguments that can be passed when running a ValidMind test, used to pass additional information to a metric, customize its behavior, or provide additional context.\n",
-        "\n",
-        "**Outputs**: Custom metrics can return elements like tables or plots. Tables may be a list of dictionaries (each representing a row) or a pandas DataFrame. Plots may be matplotlib or plotly figures.\n",
-        "\n",
-        "**Test suites**: Collections of tests designed to run together to automate and generate model documentation end-to-end for specific use-cases.\n",
-        "\n",
-        "Example: the [`classifier_full_suite`](https://docs.validmind.ai/validmind/validmind/test_suites/classifier.html#ClassifierFullSuite) test suite runs tests from the [`tabular_dataset`](https://docs.validmind.ai/validmind/validmind/test_suites/tabular_datasets.html) and [`classifier`](https://docs.validmind.ai/validmind/validmind/test_suites/classifier.html) test suites to fully document the data and model sections for binary classification model use-cases.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc2_'></a>\n",
-        "\n",
-        "## <a id='toc2_'></a>Install the client library [](#toc0_)\n",
-        "\n",
-        "The client library provides Python support for the ValidMind Developer Framework. To install it:\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%pip install -q validmind"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc3_'></a>\n",
-        "\n",
-        "## <a id='toc3_'></a>Initialize the client library [](#toc0_)\n",
-        "\n",
-        "ValidMind generates a unique _code snippet_ for each registered model to connect with your developer environment. You initialize the client library with this code snippet, which ensures that your documentation and tests are uploaded to the correct model when you run the notebook.\n",
-        "\n",
-        "Get your code snippet:\n",
-        "\n",
-        "1. In a browser, log into the [Platform UI](https://app.prod.validmind.ai).\n",
-        "\n",
-        "2. In the left sidebar, navigate to **Model Inventory** and click **+ Register new model**.\n",
-        "\n",
-        "3. Enter the model details and click **Continue**. ([Need more help?](https://docs.validmind.ai/guide/register-models-in-model-inventory.html))\n",
-        "\n",
-        "   For example, to register a model for use with this notebook, select:\n",
-        "\n",
-        "   - Documentation template: `Binary classification`\n",
-        "   - Use case: `Marketing/Sales - Attrition/Churn Management`\n",
-        "\n",
-        "   You can fill in other options according to your preference.\n",
-        "\n",
-        "4. Go to **Getting Started** and click **Copy snippet to clipboard**.\n",
-        "\n",
-        "Next, replace this placeholder with your own code snippet:\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Replace with your code snippet\n",
-        "\n",
-        "import validmind as vm\n",
-        "\n",
-        "vm.init(\n",
-        "    api_host=\"https://api.prod.validmind.ai/api/v1/tracking\",\n",
-        "    api_key=\"...\",\n",
-        "    api_secret=\"...\",\n",
-        "    project=\"...\",\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc4_'></a>\n",
-        "\n",
-        "## <a id='toc4_'></a>Initialize the Python environment [](#toc0_)\n",
-        "\n",
-        "Next, let's import the necessary libraries and set up your Python environment for data analysis:\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import xgboost as xgb\n",
-        "\n",
-        "%matplotlib inline"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc4_1_'></a>\n",
-        "\n",
-        "### <a id='toc4_1_'></a>Preview the documentation template [](#toc0_)\n",
-        "\n",
-        "A template predefines sections for your model documentation and provides a general outline to follow, making the documentation process much easier.\n",
-        "\n",
-        "You will upload documentation and test results into this template later on. For now, take a look at the structure that the template provides with the `vm.preview_template()` function from the ValidMind library and note the empty sections:\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "vm.preview_template()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc5_'></a>\n",
-        "\n",
-        "## <a id='toc5_'></a>Load the sample dataset [](#toc0_)\n",
-        "\n",
-        "The sample dataset used here is provided by the ValidMind library. To be able to use it, you need to import the dataset and load it into a pandas [DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html), a two-dimensional tabular data structure that makes use of rows and columns:\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Import the sample dataset from the library\n",
-        "\n",
-        "from validmind.datasets.classification import customer_churn\n",
-        "\n",
-        "print(\n",
-        "    f\"Loaded demo dataset with: \\n\\n\\t• Target column: '{customer_churn.target_column}' \\n\\t• Class labels: {customer_churn.class_labels}\"\n",
-        ")\n",
-        "\n",
-        "raw_df = customer_churn.load_data()\n",
-        "raw_df.head()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc6_'></a>\n",
-        "\n",
-        "## <a id='toc6_'></a>Document the model [](#toc0_)\n",
-        "\n",
-        "As part of documenting the model with the ValidMind Developer Framework, you need to preprocess the raw dataset, initialize some training and test datasets, initialize a model object you can use for testing, and then run the full suite of tests.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc6_1_'></a>\n",
-        "\n",
-        "### <a id='toc6_1_'></a>Prepocess the raw dataset [](#toc0_)\n",
-        "\n",
-        "Preprocessing performs a number of operations to get ready for the subsequent steps:\n",
-        "\n",
-        "- Preprocess the data: Splits the DataFrame (`df`) into multiple datasets (`train_df`, `validation_df`, and `test_df`) using `demo_dataset.preprocess` to simplify preprocessing.\n",
-        "- Separate features and targets: Drops the target column to create feature sets (`x_train`, `x_val`) and target sets (`y_train`, `y_val`).\n",
-        "- Initialize XGBoost classifier: Creates an `XGBClassifier` object with early stopping rounds set to 10.\n",
-        "- Set evaluation metrics: Specifies metrics for model evaluation as \"error,\" \"logloss,\" and \"auc.\"\n",
-        "- Fit the model: Trains the model on `x_train` and `y_train` using the validation set `(x_val, y_val)`. Verbose output is disabled.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "train_df, validation_df, test_df = customer_churn.preprocess(raw_df)\n",
-        "\n",
-        "x_train = train_df.drop(customer_churn.target_column, axis=1)\n",
-        "y_train = train_df[customer_churn.target_column]\n",
-        "x_val = validation_df.drop(customer_churn.target_column, axis=1)\n",
-        "y_val = validation_df[customer_churn.target_column]\n",
-        "\n",
-        "model = xgb.XGBClassifier(early_stopping_rounds=10)\n",
-        "model.set_params(\n",
-        "    eval_metric=[\"error\", \"logloss\", \"auc\"],\n",
-        ")\n",
-        "model.fit(\n",
-        "    x_train,\n",
-        "    y_train,\n",
-        "    eval_set=[(x_val, y_val)],\n",
-        "    verbose=False,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc6_2_'></a>\n",
-        "\n",
-        "### <a id='toc6_2_'></a>Initialize the ValidMind datasets [](#toc0_)\n",
-        "\n",
-        "Before you can run tests, you must first initialize a ValidMind dataset object using the [`init_dataset`](https://docs.validmind.ai/validmind/validmind.html#init_dataset) function from the ValidMind (`vm`) module.\n",
-        "\n",
-        "This function takes a number of arguments:\n",
-        "\n",
-        "- `dataset` — the raw dataset that you want to provide as input to tests\n",
-        "- `input_id` - a unique identifier that allows tracking what inputs are used when running each individual test\n",
-        "- `target_column` — a required argument if tests require access to true values. This is the name of the target column in the dataset\n",
-        "- `class_labels` — an optional value to map predicted classes to class labels\n",
-        "\n",
-        "With all datasets ready, you can now initialize the raw, training and test datasets (`raw_df`, `train_df` and `test_df`) created earlier into their own dataset objects using [`vm.init_dataset()`](https://docs.validmind.ai/validmind/validmind.html#init_dataset):\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "vm_raw_dataset = vm.init_dataset(\n",
-        "    dataset=raw_df,\n",
-        "    input_id=\"raw_dataset\",\n",
-        "    target_column=customer_churn.target_column,\n",
-        "    class_labels=customer_churn.class_labels,\n",
-        ")\n",
-        "\n",
-        "vm_train_ds = vm.init_dataset(\n",
-        "    dataset=train_df,\n",
-        "    input_id=\"train_dataset\",\n",
-        "    target_column=customer_churn.target_column,\n",
-        ")\n",
-        "\n",
-        "vm_test_ds = vm.init_dataset(\n",
-        "    dataset=test_df, input_id=\"test_dataset\", target_column=customer_churn.target_column\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc6_3_'></a>\n",
-        "\n",
-        "### <a id='toc6_3_'></a>Initialize a model object [](#toc0_)\n",
-        "\n",
-        "Additionally, you need to initialize a ValidMind model object (`vm_model`) that can be passed to other functions for analysis and tests on the data. You simply intialize this model object with [`vm.init_model()`](https://docs.validmind.ai/validmind/validmind.html#init_model):\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "vm_model = vm.init_model(\n",
-        "    model,\n",
-        "    input_id=\"model\",\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc6_4_'></a>\n",
-        "\n",
-        "### <a id='toc6_4_'></a>Assign predictions to the datasets [](#toc0_)\n",
-        "\n",
-        "We can now use the assign_predictions() method from the Dataset object to link existing predictions to any model. If no prediction values are passed, the method will compute predictions automatically:\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "vm_train_ds.assign_predictions(\n",
-        "    model=vm_model,\n",
-        ")\n",
-        "\n",
-        "vm_test_ds.assign_predictions(\n",
-        "    model=vm_model,\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc6_5_'></a>\n",
-        "\n",
-        "### <a id='toc6_5_'></a>Run the full suite of tests [](#toc0_)\n",
-        "\n",
-        "This is where it all comes together: you are now ready to run the documentation tests for the model as defined by the documentation template you looked at earlier.\n",
-        "\n",
-        "The [`vm.run_documentation_tests`](https://docs.validmind.ai/validmind/validmind.html#run_documentation_tests) function finds and runs every test specified in the template and then uploads all the documentation and test artifacts that get generated to the ValidMind AI Risk Platform.\n",
-        "\n",
-        "The function requires information about the inputs to use on every test. These inputs can be passed as an `inputs` argument if we want to use the same inputs for all tests. It's also possible to pass a `config` argument that has information about the `params` and `inputs` that each test requires. The `config` parameter is a dictionary with the following structure:\n",
-        "\n",
-        "```python\n",
-        "config = {\n",
-        "    \"<test-id>\": {\n",
-        "        \"params\": {\n",
-        "            \"param1\": \"value1\",\n",
-        "            \"param2\": \"value2\",\n",
-        "            ...\n",
-        "        },\n",
-        "        \"inputs\": {\n",
-        "            \"input1\": \"value1\",\n",
-        "            \"input2\": \"value2\",\n",
-        "            ...\n",
-        "        }\n",
-        "    },\n",
-        "    ...\n",
-        "}\n",
-        "```\n",
-        "\n",
-        "Each `<test-id>` above corresponds to the test driven block identifiers shown by `vm.preview_template()`. For this model, we will use the default parameters for all tests, but we'll need to specify the input configuration for each one. The method `get_demo_test_config()` below constructs the default input configuration for our demo.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from validmind.utils import preview_test_config\n",
-        "\n",
-        "test_config = customer_churn.get_demo_test_config()\n",
-        "preview_test_config(test_config)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Now we can pass the input configuration to `vm.run_documentation_tests()` and run the full suite of tests. The variable `full_suite` then holds the result of these tests.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "full_suite = vm.run_documentation_tests(config=test_config)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "<a id='toc7_'></a>\n",
-        "\n",
-        "## <a id='toc7_'></a>Next steps [](#toc0_)\n",
-        "\n",
-        "You can look at the results of this test suite right in the notebook where you ran the code, as you would expect. But there is a better way — use the ValidMind platform to work with your model documentation.\n",
-        "\n",
-        "<a id='toc7_1_'></a>\n",
-        "\n",
-        "### <a id='toc7_1_'></a>Work with your model documentation [](#toc0_)\n",
-        "\n",
-        "1. From the [**Model Inventory**](https://app.prod.validmind.ai/model-inventory) in the ValidMind Platform UI, go to the model you registered earlier.\n",
-        "\n",
-        "2. Click and expand the **Model Development** section.\n",
-        "\n",
-        "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
-        "\n",
-        "<a id='toc7_2_'></a>\n",
-        "\n",
-        "### <a id='toc7_2_'></a>Discover more learning resources [](#toc0_)\n",
-        "\n",
-        "We offer many interactive notebooks to help you document models:\n",
-        "\n",
-        "- [Run tests & test suites](https://docs.validmind.ai/guide/testing-overview.html)\n",
-        "- [Code samples](https://docs.validmind.ai/guide/samples-jupyter-notebooks.html)\n",
-        "\n",
-        "Or, visit our [documentation](https://docs.validmind.ai/) to learn more about ValidMind."
-      ]
-    }
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "# Quickstart for model documentation\n",
+     "\n",
+     "Welcome! Let's get you started with the basic process of documenting models with ValidMind.\n",
+     "\n",
+     "You will learn how to initialize the ValidMind Developer Framework, load a sample dataset to train a simple classification model, and then run a ValidMind test suite to quickly generate documentation about the data and model.\n",
+     "\n",
+     "This notebook uses the [Bank Customer Churn Prediction](https://www.kaggle.com/code/kmalit/bank-customer-churn-prediction/data) sample dataset from Kaggle to train the classification model."
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc0_'></a>\n",
+     "\n",
+     "## Contents    \n",
+     "- [About ValidMind](#toc1_)    \n",
+     "  - [Before you begin](#toc1_1_)    \n",
+     "  - [New to ValidMind?](#toc1_2_)    \n",
+     "  - [Key concepts](#toc1_3_)    \n",
+     "- [Install the client library](#toc2_)\n",
+     "  - [Get your code snippet](#toc3_1_)\n",
+     "- [Initialize the client library](#toc3_)    \n",
+     "- [Initialize the Python environment](#toc4_)    \n",
+     "  - [Preview the documentation template](#toc4_1_)    \n",
+     "- [Load the sample dataset](#toc5_)    \n",
+     "- [Document the model](#toc6_)    \n",
+     "  - [Prepocess the raw dataset](#toc6_1_)    \n",
+     "  - [Initialize the ValidMind datasets](#toc6_2_)    \n",
+     "  - [Initialize a model object](#toc6_3_)    \n",
+     "  - [Assign predictions to the datasets](#toc6_4_)    \n",
+     "  - [Run the full suite of tests](#toc6_5_)    \n",
+     "- [Next steps](#toc7_)    \n",
+     "  - [Work with your model documentation](#toc7_1_)    \n",
+     "  - [Discover more learning resources](#toc7_2_)    \n",
+     "\n",
+     "<!-- vscode-jupyter-toc-config\n",
+     "\tnumbering=false\n",
+     "\tanchor=true\n",
+     "\tflat=false\n",
+     "\tminLevel=2\n",
+     "\tmaxLevel=4\n",
+     "\t/vscode-jupyter-toc-config -->\n",
+     "<!-- THIS CELL WILL BE REPLACED ON TOC UPDATE. DO NOT WRITE YOUR TEXT IN THIS CELL -->"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc1_'></a>\n",
+     "\n",
+     "## About ValidMind\n",
+     "\n",
+     "ValidMind is a platform for managing model risk, including risk associated with AI and statistical models.\n",
+     "\n",
+     "You use the ValidMind Developer Framework to automate documentation and validation tests, and then use the ValidMind AI Risk Platform UI to collaborate on model documentation. Together, these products simplify model risk management, facilitate compliance with regulations and institutional standards, and enhance collaboration between yourself and model validators.\n",
+     "\n",
+     "<a id='toc1_1_'></a>\n",
+     "\n",
+     "### Before you begin\n",
+     "\n",
+     "This notebook assumes you have basic familiarity with Python, including an understanding of how functions work. If you are new to Python, you can still run the notebook but we recommend further familiarizing yourself with the language. \n",
+     "\n",
+     "If you encounter errors due to missing modules in your Python environment, install the modules with `pip install`, and then re-run the notebook. For more help, refer to [Installing Python Modules](https://docs.python.org/3/installing/index.html).\n",
+     "\n",
+     "<a id='toc1_2_'></a>\n",
+     "\n",
+     "### New to ValidMind?\n",
+     "\n",
+     "If you haven't already seen our [Get started with the ValidMind Developer Framework](https://docs.validmind.ai/guide/get-started-developer-framework.html), we recommend you explore the available resources for developers at some point. There, you can learn more about documenting models, find code samples, or read our developer reference.\n",
+     "\n",
+     "<div class=\"alert alert-block alert-info\">For access to all features available in this notebook, create a free ValidMind account.\n",
+     "\n",
+     "Signing up is FREE — <a href=\"https://app.prod.validmind.ai\">Sign up now</a></div>\n",
+     "\n",
+     "<a id='toc1_3_'></a>\n",
+     "\n",
+     "### Key concepts\n",
+     "\n",
+     "**Model documentation**: A structured and detailed record pertaining to a model, encompassing key components such as its underlying assumptions, methodologies, data sources, inputs, performance metrics, evaluations, limitations, and intended uses. It serves to ensure transparency, adherence to regulatory requirements, and a clear understanding of potential risks associated with the model’s application.\n",
+     "\n",
+     "**Documentation template**: Functions as a test suite and lays out the structure of model documentation, segmented into various sections and sub-sections. Documentation templates define the structure of your model documentation, specifying the tests that should be run, and how the results should be displayed.\n",
+     "\n",
+     "**Tests**: A function contained in the ValidMind Developer Framework, designed to run a specific quantitative test on the dataset or model. Tests are the building blocks of ValidMind, used to evaluate and document models and datasets, and can be run individually or as part of a suite defined by your model documentation template.\n",
+     "\n",
+     "**Metrics**: A subset of tests that do not have thresholds. In the context of this notebook, metrics and tests can be thought of as interchangeable concepts.\n",
+     "\n",
+     "**Custom metrics**: Custom metrics are functions that you define to evaluate your model or dataset. These functions can be registered with ValidMind to be used in the platform.\n",
+     "\n",
+     "**Inputs**: Objects to be evaluated and documented in the ValidMind framework. They can be any of the following:\n",
+     "\n",
+     "  - **model**: A single model that has been initialized in ValidMind with [`vm.init_model()`](https://docs.validmind.ai/validmind/validmind.html#init_model).\n",
+     "  - **dataset**: Single dataset that has been initialized in ValidMind with [`vm.init_dataset()`](https://docs.validmind.ai/validmind/validmind.html#init_dataset).\n",
+     "  - **models**: A list of ValidMind models - usually this is used when you want to compare multiple models in your custom metric.\n",
+     "  - **datasets**: A list of ValidMind datasets - usually this is used when you want to compare multiple datasets in your custom metric. See this [example](https://docs.validmind.ai/notebooks/how_to/run_tests_that_require_multiple_datasets.html) for more information.\n",
+     "\n",
+     "**Parameters**: Additional arguments that can be passed when running a ValidMind test, used to pass additional information to a metric, customize its behavior, or provide additional context.\n",
+     "\n",
+     "**Outputs**: Custom metrics can return elements like tables or plots. Tables may be a list of dictionaries (each representing a row) or a pandas DataFrame. Plots may be matplotlib or plotly figures.\n",
+     "\n",
+     "**Test suites**: Collections of tests designed to run together to automate and generate model documentation end-to-end for specific use-cases.\n",
+     "\n",
+     "Example: the [`classifier_full_suite`](https://docs.validmind.ai/validmind/validmind/test_suites/classifier.html#ClassifierFullSuite) test suite runs tests from the [`tabular_dataset`](https://docs.validmind.ai/validmind/validmind/test_suites/tabular_datasets.html) and [`classifier`](https://docs.validmind.ai/validmind/validmind/test_suites/classifier.html) test suites to fully document the data and model sections for binary classification model use-cases.\n"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc2_'></a>\n",
+     "\n",
+     "## Install the client library\n",
+     "\n",
+     "The client library provides Python support for the ValidMind Developer Framework. To install it:\n"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "%pip install -q validmind"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc3_'></a>\n",
+     "\n",
+     "## Initialize the client library\n",
+     "\n",
+     "ValidMind generates a unique _code snippet_ for each registered model to connect with your developer environment. You initialize the client library with this code snippet, which ensures that your documentation and tests are uploaded to the correct model when you run the notebook.\n",
+     "\n",
+     "<a id='toc3_1_'></a>\n",
+     "### Get your code snippet\n",
+     "\n",
+     "1. In a browser, log into the [Platform UI](https://app.prod.validmind.ai).\n",
+     "\n",
+     "2. In the left sidebar, navigate to **Model Inventory** and click **+ Register new model**.\n",
+     "\n",
+     "3. Enter the model details and click **Continue**. ([Need more help?](https://docs.validmind.ai/guide/register-models-in-model-inventory.html))\n",
+     "\n",
+     "   For example, to register a model for use with this notebook, select:\n",
+     "\n",
+     "   - Documentation template: `Binary classification`\n",
+     "   - Use case: `Marketing/Sales - Attrition/Churn Management`\n",
+     "\n",
+     "   You can fill in other options according to your preference.\n",
+     "\n",
+     "4. Go to **Getting Started** and click **Copy snippet to clipboard**.\n",
+     "\n",
+     "Next, replace this placeholder with your own code snippet:\n"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "# Replace with your code snippet\n",
+     "\n",
+     "import validmind as vm\n",
+     "\n",
+     "vm.init(\n",
+     "    api_host=\"https://api.prod.validmind.ai/api/v1/tracking\",\n",
+     "    api_key=\"...\",\n",
+     "    api_secret=\"...\",\n",
+     "    project=\"...\",\n",
+     ")"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc4_'></a>\n",
+     "\n",
+     "## Initialize the Python environment\n",
+     "\n",
+     "Next, let's import the necessary libraries and set up your Python environment for data analysis:\n"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "import xgboost as xgb\n",
+     "\n",
+     "%matplotlib inline"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc4_1_'></a>\n",
+     "\n",
+     "### Preview the documentation template\n",
+     "\n",
+     "A template predefines sections for your model documentation and provides a general outline to follow, making the documentation process much easier.\n",
+     "\n",
+     "You will upload documentation and test results into this template later on. For now, take a look at the structure that the template provides with the `vm.preview_template()` function from the ValidMind library and note the empty sections:\n"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "vm.preview_template()"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc5_'></a>\n",
+     "\n",
+     "## Load the sample dataset\n",
+     "\n",
+     "The sample dataset used here is provided by the ValidMind library. To be able to use it, you need to import the dataset and load it into a pandas [DataFrame](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html), a two-dimensional tabular data structure that makes use of rows and columns:\n"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "# Import the sample dataset from the library\n",
+     "\n",
+     "from validmind.datasets.classification import customer_churn\n",
+     "\n",
+     "print(\n",
+     "    f\"Loaded demo dataset with: \\n\\n\\t• Target column: '{customer_churn.target_column}' \\n\\t• Class labels: {customer_churn.class_labels}\"\n",
+     ")\n",
+     "\n",
+     "raw_df = customer_churn.load_data()\n",
+     "raw_df.head()"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc6_'></a>\n",
+     "\n",
+     "## Document the model\n",
+     "\n",
+     "As part of documenting the model with the ValidMind Developer Framework, you need to preprocess the raw dataset, initialize some training and test datasets, initialize a model object you can use for testing, and then run the full suite of tests.\n"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc6_1_'></a>\n",
+     "\n",
+     "### Prepocess the raw dataset\n",
+     "\n",
+     "Preprocessing performs a number of operations to get ready for the subsequent steps:\n",
+     "\n",
+     "- Preprocess the data: Splits the DataFrame (`df`) into multiple datasets (`train_df`, `validation_df`, and `test_df`) using `demo_dataset.preprocess` to simplify preprocessing.\n",
+     "- Separate features and targets: Drops the target column to create feature sets (`x_train`, `x_val`) and target sets (`y_train`, `y_val`).\n",
+     "- Initialize XGBoost classifier: Creates an `XGBClassifier` object with early stopping rounds set to 10.\n",
+     "- Set evaluation metrics: Specifies metrics for model evaluation as \"error,\" \"logloss,\" and \"auc.\"\n",
+     "- Fit the model: Trains the model on `x_train` and `y_train` using the validation set `(x_val, y_val)`. Verbose output is disabled.\n"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "train_df, validation_df, test_df = customer_churn.preprocess(raw_df)\n",
+     "\n",
+     "x_train = train_df.drop(customer_churn.target_column, axis=1)\n",
+     "y_train = train_df[customer_churn.target_column]\n",
+     "x_val = validation_df.drop(customer_churn.target_column, axis=1)\n",
+     "y_val = validation_df[customer_churn.target_column]\n",
+     "\n",
+     "model = xgb.XGBClassifier(early_stopping_rounds=10)\n",
+     "model.set_params(\n",
+     "    eval_metric=[\"error\", \"logloss\", \"auc\"],\n",
+     ")\n",
+     "model.fit(\n",
+     "    x_train,\n",
+     "    y_train,\n",
+     "    eval_set=[(x_val, y_val)],\n",
+     "    verbose=False,\n",
+     ")"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc6_2_'></a>\n",
+     "\n",
+     "### Initialize the ValidMind datasets\n",
+     "\n",
+     "Before you can run tests, you must first initialize a ValidMind dataset object using the [`init_dataset`](https://docs.validmind.ai/validmind/validmind.html#init_dataset) function from the ValidMind (`vm`) module.\n",
+     "\n",
+     "This function takes a number of arguments:\n",
+     "\n",
+     "- `dataset` — the raw dataset that you want to provide as input to tests\n",
+     "- `input_id` - a unique identifier that allows tracking what inputs are used when running each individual test\n",
+     "- `target_column` — a required argument if tests require access to true values. This is the name of the target column in the dataset\n",
+     "- `class_labels` — an optional value to map predicted classes to class labels\n",
+     "\n",
+     "With all datasets ready, you can now initialize the raw, training and test datasets (`raw_df`, `train_df` and `test_df`) created earlier into their own dataset objects using [`vm.init_dataset()`](https://docs.validmind.ai/validmind/validmind.html#init_dataset):\n"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "vm_raw_dataset = vm.init_dataset(\n",
+     "    dataset=raw_df,\n",
+     "    input_id=\"raw_dataset\",\n",
+     "    target_column=customer_churn.target_column,\n",
+     "    class_labels=customer_churn.class_labels,\n",
+     ")\n",
+     "\n",
+     "vm_train_ds = vm.init_dataset(\n",
+     "    dataset=train_df,\n",
+     "    input_id=\"train_dataset\",\n",
+     "    target_column=customer_churn.target_column,\n",
+     ")\n",
+     "\n",
+     "vm_test_ds = vm.init_dataset(\n",
+     "    dataset=test_df, input_id=\"test_dataset\", target_column=customer_churn.target_column\n",
+     ")"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc6_3_'></a>\n",
+     "\n",
+     "### Initialize a model object\n",
+     "\n",
+     "Additionally, you need to initialize a ValidMind model object (`vm_model`) that can be passed to other functions for analysis and tests on the data. You simply intialize this model object with [`vm.init_model()`](https://docs.validmind.ai/validmind/validmind.html#init_model):\n"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "vm_model = vm.init_model(\n",
+     "    model,\n",
+     "    input_id=\"model\",\n",
+     ")"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc6_4_'></a>\n",
+     "\n",
+     "### Assign predictions to the datasets\n",
+     "\n",
+     "We can now use the assign_predictions() method from the Dataset object to link existing predictions to any model. If no prediction values are passed, the method will compute predictions automatically:\n"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "vm_train_ds.assign_predictions(\n",
+     "    model=vm_model,\n",
+     ")\n",
+     "\n",
+     "vm_test_ds.assign_predictions(\n",
+     "    model=vm_model,\n",
+     ")"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc6_5_'></a>\n",
+     "\n",
+     "### Run the full suite of tests\n",
+     "\n",
+     "This is where it all comes together: you are now ready to run the documentation tests for the model as defined by the documentation template you looked at earlier.\n",
+     "\n",
+     "The [`vm.run_documentation_tests`](https://docs.validmind.ai/validmind/validmind.html#run_documentation_tests) function finds and runs every test specified in the template and then uploads all the documentation and test artifacts that get generated to the ValidMind AI Risk Platform.\n",
+     "\n",
+     "The function requires information about the inputs to use on every test. These inputs can be passed as an `inputs` argument if we want to use the same inputs for all tests. It's also possible to pass a `config` argument that has information about the `params` and `inputs` that each test requires. The `config` parameter is a dictionary with the following structure:\n",
+     "\n",
+     "```python\n",
+     "config = {\n",
+     "    \"<test-id>\": {\n",
+     "        \"params\": {\n",
+     "            \"param1\": \"value1\",\n",
+     "            \"param2\": \"value2\",\n",
+     "            ...\n",
+     "        },\n",
+     "        \"inputs\": {\n",
+     "            \"input1\": \"value1\",\n",
+     "            \"input2\": \"value2\",\n",
+     "            ...\n",
+     "        }\n",
+     "    },\n",
+     "    ...\n",
+     "}\n",
+     "```\n",
+     "\n",
+     "Each `<test-id>` above corresponds to the test driven block identifiers shown by `vm.preview_template()`. For this model, we will use the default parameters for all tests, but we'll need to specify the input configuration for each one. The method `get_demo_test_config()` below constructs the default input configuration for our demo.\n"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "from validmind.utils import preview_test_config\n",
+     "\n",
+     "test_config = customer_churn.get_demo_test_config()\n",
+     "preview_test_config(test_config)"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "Now we can pass the input configuration to `vm.run_documentation_tests()` and run the full suite of tests. The variable `full_suite` then holds the result of these tests.\n"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": null,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "full_suite = vm.run_documentation_tests(config=test_config)"
+    ]
+   },
+   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "<a id='toc7_'></a>\n",
+     "\n",
+     "## Next steps\n",
+     "\n",
+     "You can look at the results of this test suite right in the notebook where you ran the code, as you would expect. But there is a better way — use the ValidMind platform to work with your model documentation.\n",
+     "\n",
+     "<a id='toc7_1_'></a>\n",
+     "\n",
+     "### Work with your model documentation\n",
+     "\n",
+     "1. From the [**Model Inventory**](https://app.prod.validmind.ai/model-inventory) in the ValidMind Platform UI, go to the model you registered earlier.\n",
+     "\n",
+     "2. Click and expand the **Model Development** section.\n",
+     "\n",
+     "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+     "\n",
+     "<a id='toc7_2_'></a>\n",
+     "\n",
+     "### Discover more learning resources\n",
+     "\n",
+     "We offer many interactive notebooks to help you document models:\n",
+     "\n",
+     "- [Run tests & test suites](https://docs.validmind.ai/guide/testing-overview.html)\n",
+     "- [Code samples](https://docs.validmind.ai/guide/samples-jupyter-notebooks.html)\n",
+     "\n",
+     "Or, visit our [documentation](https://docs.validmind.ai/) to learn more about ValidMind."
+    ]
+   }
   ],
   "metadata": {
-    "colab": {
-      "provenance": []
+   "colab": {
+    "provenance": []
+   },
+   "gpuClass": "standard",
+   "kernelspec": {
+    "display_name": "Python 3 (ipykernel)",
+    "language": "python",
+    "name": "python3"
+   },
+   "language_info": {
+    "codemirror_mode": {
+     "name": "ipython",
+     "version": 3
     },
-    "gpuClass": "standard",
-    "kernelspec": {
-      "display_name": "local-venv",
-      "language": "python",
-      "name": "local-venv"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.9.13"
-    }
+    "file_extension": ".py",
+    "mimetype": "text/x-python",
+    "name": "python",
+    "nbconvert_exporter": "python",
+    "pygments_lexer": "ipython3",
+    "version": "3.10.14"
+   }
   },
   "nbformat": 4,
-  "nbformat_minor": 0
-}
+  "nbformat_minor": 4
+ }
+ 


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR includes some minor tweaks to the QuickStart notebook: 

- Fix CTA callout for signups, now uses HTML that always renders correctly
- Add a “Get your code snippet” heading that makes it easier to spot where you need to go
- Remove duplicate TOC anchors in headings

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->