### PR TITLE
Fixed broken links in integrate_external_test_providers.ipynb

### DIFF
--- a/notebooks/code_samples/custom_tests/integrate_external_test_providers.ipynb
+++ b/notebooks/code_samples/custom_tests/integrate_external_test_providers.ipynb
@@ -8,7 +8,7 @@
         "\n",
         "Register a custom test provider with the Validmind Developer Framework to run your own tests.\n",
         "\n",
-        "The ValidMind Developer framework offers the ability to extend the built-in library of tests (metrics) with custom tests. If you've followed along in the [implementing_custom_tests.ipynb](./implementing_custom_tests.ipynb), you will be familiar with the process of creating custom tests and running them for use in your model documentation. In that notebook, the tests were defined inline, as a notebook cell, using the `validmind.metric` decorator. This works very well when you just want to create one-off, ad-hoc tests or for experimenting. But for more complex, reusable and shareable tests, it is recommended to use a more structured approach.\n",
+        "The ValidMind Developer framework offers the ability to extend the built-in library of tests (metrics) with custom tests. If you've followed along in the [Implement custom tests notebook](./implement_custom_tests.ipynb), you will be familiar with the process of creating custom tests and running them for use in your model documentation. In that notebook, the tests were defined inline, as a notebook cell, using the `validmind.metric` decorator. This works very well when you just want to create one-off, ad-hoc tests or for experimenting. But for more complex, reusable and shareable tests, it is recommended to use a more structured approach.\n",
         "\n",
         "This is where the concept of External Test Providers come in. A test \"Provider\" is a Python class that gets registered with the ValidMind Framework and loads tests based on a test ID, for example `my_test_provider.my_test_id`. The built-in suite of tests that ValidMind offers is technically its own test provider. You can use one the built-in test provider offered by ValidMind (`validmind.tests.test_providers.LocalTestProvider`) or you can create your own. More than likely, you'll want to use the `LocalTestProvider` to add a directory of custom tests but there's flexibility to be able to load tests from any source.\n",
         "\n",
@@ -58,9 +58,11 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc1_'></a>\n\n## Prerequisites\n",
+        "<a id='toc1_'></a>\n",
         "\n",
-        "As mentioned above, its recommended that you have gone through the [implementing_custom_tests.ipynb](./implementing_custom_tests.ipynb) notebook to understand the basics of creating custom tests. We will be using the same tests defined in that notebook.\n",
+        "## Prerequisites\n",
+        "\n",
+        "As mentioned above, its recommended that you have gone through the [Implement custom tests notebook](./implement_custom_tests.ipynb) to understand the basics of creating custom tests. We will be using the same tests defined in that notebook.\n",
         "\n",
         "If you encounter errors due to missing modules in your Python environment, install the modules with `pip install`, and then re-run the notebook. For more help, refer to [Installing Python Modules](https://docs.python.org/3/installing/index.html)."
       ]
@@ -69,7 +71,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc2_'></a>\n\n## Key concepts\n",
+        "<a id='toc2_'></a>\n",
+        "\n",
+        "## Key concepts\n",
         "\n",
         "- **Test Provider**: A Python class that gets registered with the ValidMind Framework and loads tests based on a test ID e.g. `my_test_provider.my_test_id`.\n",
         "- **LocalTestProvider**: A built-in test provider that loads tests from a local directory.\n",
@@ -84,7 +88,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc3_'></a>\n\n## High-level steps\n",
+        "<a id='toc3_'></a>\n",
+        "\n",
+        "## High-level steps\n",
         "\n",
         "1. Create a folder of custom tests from existing, inline tests.\n",
         "2. Define and register a `LocalTestProvider` that points to that folder.\n",
@@ -97,7 +103,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc4_'></a>\n\n## About ValidMind\n",
+        "<a id='toc4_'></a>\n",
+        "\n",
+        "## About ValidMind\n",
         "\n",
         "ValidMind's platform enables organizations to identify, document, and manage model risks for all types of models, including AI/ML models, LLMs, and statistical models. As a model developer, you use the ValidMind Developer Framework to automate documentation and validation tests, and then use the ValidMind AI Risk Platform UI to collaborate on model documentation. Together, these products simplify model risk management, facilitate compliance with regulations and institutional standards, and enhance collaboration between yourself and model validators.\n",
         "\n",
@@ -106,11 +114,15 @@
         "- [Get started](https://docs.validmind.ai/guide/get-started.html) — The basics, including key concepts, and how our products work\n",
         "- [Get started with the ValidMind Developer Framework](https://docs.validmind.ai/guide/get-started-developer-framework.html) — The path for developers, more code samples, and our developer reference\n",
         "\n",
-        "<a id='toc4_1_'></a>\n\n### Before you begin\n",
+        "<a id='toc4_1_'></a>\n",
+        "\n",
+        "### Before you begin\n",
         "\n",
         "::: {.callout-tip}\n",
         "\n",
-        "<a id='toc4_2_'></a>\n\n### New to ValidMind?\n",
+        "<a id='toc4_2_'></a>\n",
+        "\n",
+        "### New to ValidMind?\n",
         "\n",
         "For access to all features available in this notebook, create a free ValidMind account.\n",
         "\n",
@@ -122,7 +134,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc5_'></a>\n\n## Install the client library\n",
+        "<a id='toc5_'></a>\n",
+        "\n",
+        "## Install the client library\n",
         "\n",
         "The client library provides Python support for the ValidMind Developer Framework. To install it:\n"
       ]
@@ -140,7 +154,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc6_'></a>\n\n## Initialize the client library\n",
+        "<a id='toc6_'></a>\n",
+        "\n",
+        "## Initialize the client library\n",
         "\n",
         "ValidMind generates a unique _code snippet_ for each registered model to connect with your developer environment. You initialize the client library with this code snippet, which ensures that your documentation and tests are uploaded to the correct model when you run the notebook.\n",
         "\n",
@@ -179,9 +195,11 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc7_'></a>\n\n## Set up custom tests\n",
+        "<a id='toc7_'></a>\n",
         "\n",
-        "If you've gone through the `implementing_custom_tests.ipynb` notebook, you should have a good understanding of how custom tests are implemented. If you haven't, we recommend going through that notebook first. In this notebook, we will take those custom tests and move them into separate modules in a folder. This is the logical progression from the previous notebook, as it allows you to take one-off tests and move them into an organized structure that makes it easier to manage, maintain and share them.\n",
+        "## Set up custom tests\n",
+        "\n",
+        "If you've gone through the [Implement custom tests notebook](./implement_custom_tests.ipynb), you should have a good understanding of how custom tests are implemented. If you haven't, we recommend going through that notebook first. In this notebook, we will take those custom tests and move them into separate modules in a folder. This is the logical progression from the previous notebook, as it allows you to take one-off tests and move them into an organized structure that makes it easier to manage, maintain and share them.\n",
         "\n",
         "First let's set the path to our custom tests folder."
       ]
@@ -440,14 +458,18 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc8_'></a>\n\n## Registering the test provider"
+        "<a id='toc8_'></a>\n",
+        "\n",
+        "## Registering the test provider"
       ]
     },
     {
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc8_1_'></a>\n\n### Test providers overview\n",
+        "<a id='toc8_1_'></a>\n",
+        "\n",
+        "### Test providers overview\n",
         "\n",
         "Now that we have a folder with our custom tests, we can create a test provider that will tell the ValidMind Developer Framework where to find these tests. ValidMind offers out-of-the-box test providers for local tests (i.e. tests in a folder) or a Github provider for tests in a Github repository. You can also create your own test provider by creating a class that has a `load_test` method that takes a test ID and returns the test function matching that ID. The protocol for test providers is below:\n",
         "\n",
@@ -476,7 +498,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc8_2_'></a>\n\n### Local test provider\n",
+        "<a id='toc8_2_'></a>\n",
+        "\n",
+        "### Local test provider\n",
         "\n",
         "For most use-cases, the local test provider should be sufficient. Let's go ahead and see how we can do this with our custom tests."
       ]
@@ -504,7 +528,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc8_3_'></a>\n\n### Running test provider tests\n",
+        "<a id='toc8_3_'></a>\n",
+        "\n",
+        "### Running test provider tests\n",
         "\n",
         "Now that we have our test provider set up, we can run any test that's located in our tests folder by using the `run_test()` method. This function is your entry point to running single tests in the ValidMind Developer Framework. It takes a test ID and runs the test associated with that ID. For our custom tests, the test ID will be the `namespace` specified when registering the provider, followed by the path to the test file relative to the tests folder. For example, the Confusion Matrix test we created earlier will have the test ID `my_test_provider.ConfusionMatrix`. You could organize the tests in subfolders, say `classification` and `regression`, and the test ID for the Confusion Matrix test would then be `my_test_provider.classification.ConfusionMatrix`.\n",
         "\n",
@@ -515,7 +541,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc8_3_1_'></a>\n\n#### Set up the model and dataset\n",
+        "<a id='toc8_3_1_'></a>\n",
+        "\n",
+        "#### Set up the model and dataset\n",
         "\n",
         "First let's setup a an example model and dataset to run our custom metic against. Since this is a Confusion Matrix, we will use the Customer Churn dataset that ValidMind provides and train a simple XGBoost model."
       ]
@@ -589,7 +617,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc8_3_2_'></a>\n\n#### Run the tests\n",
+        "<a id='toc8_3_2_'></a>\n",
+        "\n",
+        "#### Run the tests\n",
         "\n",
         "Now that we have our model and dataset setup, we can run our custom tests against them. Let's go ahead and run the Confusion Matrix test."
       ]
@@ -609,7 +639,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "You should see the output of the test above. If you want to learn more about how test functions are run and get turned into test results, check out the `implementing_custom_tests.ipynb` notebook.\n",
+        "You should see the output of the test above. If you want to learn more about how test functions are run and get turned into test results, check out the [Implement custom tests notebook](./implement_custom_tests.ipynb).\n",
         "\n",
         "Let's go ahead and log the result to the ValidMind platform."
       ]
@@ -627,7 +657,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc8_3_3_'></a>\n\n#### Add custom metrics to model documentation\n",
+        "<a id='toc8_3_3_'></a>\n",
+        "\n",
+        "#### Add custom metrics to model documentation\n",
         "\n",
         "Now that the result has been logged to the platform, you can add it to your model documentation. This will add the result where you specify but it also will add the test to the template so it gets run anytime you `run_documentation_tests()`. To do this, go to the documentation page of the model you connected to above and navigate to the `Model Development` -> `Model Evaluation` section. Then hover between any existing content block to reveal the `+` button as shown in the screenshot below.\n",
         "\n",
@@ -649,7 +681,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc8_3_4_'></a>\n\n#### Run, save, and add other tests\n",
+        "<a id='toc8_3_4_'></a>\n",
+        "\n",
+        "#### Run, save, and add other tests\n",
         "\n",
         "Let's take the same steps for all of our other custom tests."
       ]
@@ -682,7 +716,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc8_4_'></a>\n\n### Verify that `preview_template()` now loads the tests from the test providers\n",
+        "<a id='toc8_4_'></a>\n",
+        "\n",
+        "### Verify that `preview_template()` now loads the tests from the test providers\n",
         "\n",
         "Now that we have added the tests to the model documentation, we can run the `preview_template()` method to see the tests run automatically.\n",
         "\n",
@@ -718,7 +754,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc8_5_'></a>\n\n### Run the documentation tests\n",
+        "<a id='toc8_5_'></a>\n",
+        "\n",
+        "### Run the documentation tests\n",
         "\n",
         "Now we can run the documentation tests as normal. This should include all of our custom tests which will be loaded from our test provider folder."
       ]
@@ -737,7 +775,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc9_'></a>\n\n## Conclusion\n",
+        "<a id='toc9_'></a>\n",
+        "\n",
+        "## Conclusion\n",
         "\n",
         "In this notebook, we showed how to integrate custom tests into the ValidMind Developer Framework. We created a custom test provider that loads tests from a folder and then ran the tests against a model and dataset. We then added the tests to the model documentation and ran the documentation tests to see all of the tests run automatically. This is a powerful concept that allows you to create, organize and, most importantly, share custom tests with other model developers."
       ]
@@ -746,11 +786,15 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "<a id='toc10_'></a>\n\n## Next steps\n",
+        "<a id='toc10_'></a>\n",
+        "\n",
+        "## Next steps\n",
         "\n",
         "You can look at the results of this test suite right in the notebook where you ran the code, as you would expect. But there is a better way — use the ValidMind platform to work with your model documentation.\n",
         "\n",
-        "<a id='toc10_1_'></a>\n\n### Work with your model documentation\n",
+        "<a id='toc10_1_'></a>\n",
+        "\n",
+        "### Work with your model documentation\n",
         "\n",
         "1. From the [**Model Inventory**](https://app.prod.validmind.ai/model-inventory) in the ValidMind Platform UI, go to the model you registered earlier.\n",
         "\n",
@@ -758,7 +802,9 @@
         "\n",
         "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
         "\n",
-        "<a id='toc10_2_'></a>\n\n### Discover more learning resources\n",
+        "<a id='toc10_2_'></a>\n",
+        "\n",
+        "### Discover more learning resources\n",
         "\n",
         "We offer many interactive notebooks to help you document models:\n",
         "\n",


### PR DESCRIPTION
## Internal Notes for Reviewers

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

I fixed the broken links in `integrate_external_test_providers.ipynb` by changing the link from `implementing_ ...` to `implement_ ...`. Also changed the hyperlink text to be the title instead of the file name.

| Before | After |
| ----- | ----- |
| <img width="255" alt="image" src="https://github.com/validmind/developer-framework/assets/143854391/602c421c-824f-4e60-8270-7b04ec18bac7"> | <img width="264" alt="image" src="https://github.com/validmind/developer-framework/assets/143854391/0468e8f6-6daf-49f7-826b-ac69a26ca962"> |
| <img width="289" alt="image" src="https://github.com/validmind/developer-framework/assets/143854391/3d017380-14b9-4965-ab09-26b3ffa4ad7d"> | <img width="545" alt="image" src="https://github.com/validmind/developer-framework/assets/143854391/3638d495-45c1-4b2d-9904-50a32282b71b"> |

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->