### PR TITLE
Allow passing section_id and position to result.log()

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -239,8 +239,8 @@ class TestAPIClient(unittest.TestCase):
 
         mock_log_test_result.assert_has_calls(
             [
-                call(results[0], ["input1"], "training"),
-                call(results[1], ["input1"], "training"),
+                call(results[0], ["input1"]),
+                call(results[1], ["input1"]),
             ]
         )
 

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -226,7 +226,7 @@ class TestAPIClient(unittest.TestCase):
         self.run_async(api_client.log_test_result, result, ["input1"])
 
         url = f"{os.environ['VM_API_HOST']}/log_test_results"
-        url += f"?dataset_type=training&run_cuid={os.environ['VM_RUN_CUID']}"
+        url += f"?run_cuid={os.environ['VM_RUN_CUID']}"
 
         mock_post.assert_called_with(
             url, data=json.dumps({"key": "value", "inputs": ["input1"]})

--- a/tests/test_api_client_sync.py
+++ b/tests/test_api_client_sync.py
@@ -1,4 +1,5 @@
 """Test all of the public synchronous functions that call the async api client functions"""
+
 import json
 import os
 import unittest
@@ -65,7 +66,9 @@ class TestAPIClient(unittest.TestCase):
         vm.log_metrics(metrics, inputs=["input1"])
 
         url = f"{os.environ['VM_API_HOST']}/log_metrics?run_cuid={os.environ['VM_RUN_CUID']}"
-        mock_post.assert_called_with(url, data=json.dumps([{"key": "value", "inputs": ["input1"]}]))
+        mock_post.assert_called_with(
+            url, data=json.dumps([{"key": "value", "inputs": ["input1"]}])
+        )
 
     @patch("validmind.api_client.log_test_result")
     def test_log_test_results(self, mock_log_test_result: MagicMock):
@@ -74,8 +77,8 @@ class TestAPIClient(unittest.TestCase):
 
         mock_log_test_result.assert_has_calls(
             [
-                call(results[0], ["input1"], "training"),
-                call(results[1], ["input1"], "training"),
+                call(results[0], ["input1"]),
+                call(results[1], ["input1"]),
             ]
         )
 

--- a/validmind/api_client.py
+++ b/validmind/api_client.py
@@ -161,14 +161,20 @@ def __ping() -> Dict[str, Any]:
 
     init_sentry(client_info.get("sentry_config", {}))
 
+    # Only show this confirmation the first time we connect to the API
+    ack_connected = False
+    if client_config.project is None:
+        ack_connected = True
+
     client_config.project = client_info["project"]
     client_config.documentation_template = client_info.get("documentation_template", {})
     client_config.feature_flags = client_info.get("feature_flags", {})
 
-    logger.info(
-        f"Connected to ValidMind. Project: {client_config.project['name']}"
-        f" ({client_config.project['cuid']})"
-    )
+    if ack_connected:
+        logger.info(
+            f"Connected to ValidMind. Project: {client_config.project['name']}"
+            f" ({client_config.project['cuid']})"
+        )
 
 
 def reload():
@@ -358,7 +364,11 @@ async def log_metadata(
 
 
 async def log_metrics(
-    metrics: List[MetricResult], inputs: List[str], output_template: str = None
+    metrics: List[MetricResult],
+    inputs: List[str],
+    output_template: str = None,
+    section_id: str = None,
+    position: int = None,
 ) -> Dict[str, Any]:
     """Logs metrics to ValidMind API.
 
@@ -366,6 +376,8 @@ async def log_metrics(
         metrics (list): A list of MetricResult objects
         inputs (list): A list of input keys (names) that were used to run the test
         output_template (str): The optional output template for the test
+        section_id (str): The section ID add a test driven block to the documentation
+        position (int): The position in the section to add the test driven block
 
     Raises:
         Exception: If the API call fails
@@ -373,7 +385,14 @@ async def log_metrics(
     Returns:
         dict: The response from the API
     """
+    params = {}
+    if section_id:
+        params["section_id"] = section_id
+    if position is not None:
+        params["position"] = position
+
     data = []
+
     for metric in metrics:
         metric_data = {
             **metric.serialize(),
@@ -388,6 +407,7 @@ async def log_metrics(
     try:
         return await _post(
             "log_metrics",
+            params=params,
             data=json.dumps(data, cls=NumpyEncoder, allow_nan=False),
         )
     except Exception as e:
@@ -396,7 +416,10 @@ async def log_metrics(
 
 
 async def log_test_result(
-    result: ThresholdTestResults, inputs: List[str], dataset_type: str = "training"
+    result: ThresholdTestResults,
+    inputs: List[str],
+    section_id: str = None,
+    position: int = None,
 ) -> Dict[str, Any]:
     """Logs test results information
 
@@ -406,8 +429,8 @@ async def log_test_result(
     Args:
         result (validmind.ThresholdTestResults): A ThresholdTestResults object
         inputs (list): A list of input keys (names) that were used to run the test
-        dataset_type (str, optional): The type of dataset. Can be one of
-            "training", "test", or "validation". Defaults to "training".
+        section_id (str, optional): The section ID add a test driven block to the documentation
+        position (int): The position in the section to add the test driven block
 
     Raises:
         Exception: If the API call fails
@@ -415,10 +438,16 @@ async def log_test_result(
     Returns:
         dict: The response from the API
     """
+    params = {}
+    if section_id:
+        params["section_id"] = section_id
+    if position is not None:
+        params["position"] = position
+
     try:
         return await _post(
             "log_test_results",
-            params={"dataset_type": dataset_type},
+            params=params,
             data=json.dumps(
                 {
                     **result.serialize(),
@@ -434,7 +463,7 @@ async def log_test_result(
 
 
 def log_test_results(
-    results: List[ThresholdTestResults], inputs, dataset_type: str = "training"
+    results: List[ThresholdTestResults], inputs
 ) -> List[Callable[..., Dict[str, Any]]]:
     """Logs test results information
 
@@ -444,8 +473,6 @@ def log_test_results(
     Args:
         results (list): A list of ThresholdTestResults objects
         inputs (list): A list of input keys (names) that were used to run the test
-        dataset_type (str, optional): The type of dataset. Can be one of "training",
-          "test", or "validation". Defaults to "training".
 
     Raises:
         Exception: If the API call fails
@@ -456,7 +483,7 @@ def log_test_results(
     try:
         responses = []  # TODO: use asyncio.gather
         for result in results:
-            responses.append(run_async(log_test_result, result, inputs, dataset_type))
+            responses.append(run_async(log_test_result, result, inputs))
     except Exception as e:
         logger.error("Error logging test results to ValidMind API")
         raise e

--- a/validmind/errors.py
+++ b/validmind/errors.py
@@ -339,7 +339,7 @@ def raise_api_error(error_string):
     try:
         json_response = json.loads(error_string)
         api_code = json_response.get("code")
-        api_description = json_response.get("description")
+        api_description = json_response.get("description", json_response.get("message"))
     except json.decoder.JSONDecodeError:
         api_code = "unknown"
         api_description = error_string


### PR DESCRIPTION
## Internal Notes for Reviewers

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

### New Features for `result.log()`

New enhancements have been added to the logging of individual results with the Developer Framework. Recall that individual tests can be run with `run_test` and this function returns a `result` object that allows logging to the results to the ValidMind API with a call to `.log()`:

```python
result = vm.tests.run_test(
    "validmind.data_validation.ClassImbalance",
    inputs={"dataset": vm_dataset},
)

result.log()
```

The following features have been added to the `.log()` function:

1. **Specify a Section**: 
   - You can now log the result to a specific section by using the `section_id` parameter.
   - Example:
     ```python
     result.log(section_id="model_overview")
     ```

2. **Specify a Section and Position**:
   - You can also specify the position within the section where the result should be logged. Positions start at 0.
   - Invalid positions will throw an error.
   - Example:
     ```python
     result.log(section_id="model_overview", position=2)
     ```

3. **Prevent Duplicate Logs**:
   - Calling the `.log()` method repeatedly for the same result will not create multiple blocks in the document. It ensures only one block is added at the specified location.
   - Example:
     ```python
     result.log(section_id="model_overview")
     result.log(section_id="model_overview")
     result.log(section_id="model_overview")
     ```
   - This sequence will only add one block at the end.

These enhancements make it easier to organize and manage your test result logs, providing a more structured and efficient logging process.