### PR TITLE
FIxed broken link to dev framework docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We believe in the power of collaboration and welcome contributions to the ValidM
 
 - Interested in connecting with fellow AI model risk practitioners? Join our [Community Slack](site/guide/join-community.qmd)!
 
-- For more information about ValidMind's open source tests and Jupyter notebooks, read the [Developer Framework docs](https://docs.validmind.ai/guide/developer-framework.html).
+- For more information about ValidMind's open source tests and Jupyter notebooks, read the [Developer Framework docs]([https://docs.validmind.ai/guide/developer-framework.html](https://docs.validmind.ai/guide/get-started-developer-framework.html)).
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ We believe in the power of collaboration and welcome contributions to the ValidM
 
 - Interested in connecting with fellow AI model risk practitioners? Join our [Community Slack](site/guide/join-community.qmd)!
 
-- For more information about ValidMind's open source tests and Jupyter notebooks, read the [Developer Framework docs]([https://docs.validmind.ai/guide/developer-framework.html](https://docs.validmind.ai/guide/get-started-developer-framework.html)).
+- For more information about ValidMind's open source tests and Jupyter notebooks, read the [Developer Framework docs](https://docs.validmind.ai/guide/get-started-developer-framework.html).
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Developer Framework includes the Python client library, which is designed to
 
 We believe in the power of collaboration and welcome contributions to the ValidMind Developer Framework. If you've noticed a bug, have a feature request, or want to contribute a test, please create a pull request or submit an issue and refer to the [contributing guide](README.md#how-to-contribute) below.
 
-- Interested in connecting with fellow AI model risk practitioners? Join our [Community Slack](site/guide/join-community.qmd)!
+- Interested in connecting with fellow AI model risk practitioners? Join our [Community Slack](https://docs.validmind.ai/guide/join-community.html)!
 
 - For more information about ValidMind's open source tests and Jupyter notebooks, read the [Developer Framework docs](https://docs.validmind.ai/guide/get-started-developer-framework.html).
 


### PR DESCRIPTION
## Internal Notes for Reviewers

Under `Contributing to the ValidMind Developer Framework`, the link out to the "[...] Read the Developer Framework docs" is broken.

Full credit to @noosheenv for discovering this. :)

