### PR TITLE
Fix misspellings of "ValidMind"

### DIFF
--- a/notebooks/code_samples/custom_tests/integrate_external_test_providers.ipynb
+++ b/notebooks/code_samples/custom_tests/integrate_external_test_providers.ipynb
@@ -6,7 +6,7 @@
       "source": [
         "# Integrate external test providers\n",
         "\n",
-        "Register a custom test provider with the Validmind Developer Framework to run your own tests.\n",
+        "Register a custom test provider with the ValidMind Developer Framework to run your own tests.\n",
         "\n",
         "The ValidMind Developer framework offers the ability to extend the built-in library of tests (metrics) with custom tests. If you've followed along in the [Implement custom tests notebook](./implement_custom_tests.ipynb), you will be familiar with the process of creating custom tests and running them for use in your model documentation. In that notebook, the tests were defined inline, as a notebook cell, using the `validmind.metric` decorator. This works very well when you just want to create one-off, ad-hoc tests or for experimenting. But for more complex, reusable and shareable tests, it is recommended to use a more structured approach.\n",
         "\n",

--- a/notebooks/code_samples/time_series/tutorial_time_series_forecasting.ipynb
+++ b/notebooks/code_samples/time_series/tutorial_time_series_forecasting.ipynb
@@ -45,7 +45,7 @@
     "- [Run data validation test suite on processed data](#toc8_)    \n",
     "- [Load pre-trained models](#toc9_)    \n",
     "  - [Load pre-trained models](#toc9_1_)    \n",
-    "  - [Initialize Validmind models](#toc9_2_)    \n",
+    "  - [Initialize ValidMind models](#toc9_2_)    \n",
     "- [Run model validation test suite on models](#toc10_)    \n",
     "  - [Explore the time series model validation test suite](#toc10_1_)    \n",
     "  - [Run model validation test suite on a list of models](#toc10_2_)    \n",
@@ -516,7 +516,7 @@
    "source": [
     "<a id='toc9_2_'></a>\n",
     "\n",
-    "### Initialize Validmind models\n"
+    "### Initialize ValidMind models\n"
    ]
   },
   {

--- a/notebooks/code_sharing/external_tests/end_to_end_isolation_forest_external.ipynb
+++ b/notebooks/code_sharing/external_tests/end_to_end_isolation_forest_external.ipynb
@@ -36,8 +36,8 @@
             "source": [
                 "# Introduction\n",
                 "\n",
-                "This notebook demonstrates how to use a custom test provider to be able to use custom tests with the Validmind Developer Framework.\n",
-                "In the notebook, we load a couple different demo test providers and register them with the Validmind framework to be able to run a template that utilizes those tests."
+                "This notebook demonstrates how to use a custom test provider to be able to use custom tests with the ValidMind Developer Framework.\n",
+                "In the notebook, we load a couple different demo test providers and register them with the ValidMind framework to be able to run a template that utilizes those tests."
             ]
         },
         {
@@ -209,7 +209,7 @@
             "source": [
                 "# New Test Creation\n",
                 "\n",
-                "We can now take the code developed above and create a new Validmind `Test` class out of it that will be compatible with the Validmind framework."
+                "We can now take the code developed above and create a new ValidMind `Test` class out of it that will be compatible with the ValidMind framework."
             ]
         },
         {
@@ -326,7 +326,7 @@
             "source": [
                 "# External Test Providers\n",
                 "\n",
-                "Now that we have created a new test, how do we start making use of it in the Validmind framework? This is where our new External Test Provider feature comes in. As users of the framework develop their own tests which will live outside of the framework source code, how will those tests get seamlessly plugged into the framework? The answer is through the use of a `ExternalTestProvider` class. We provide a test provider class that can load tests from a folder. Each can be configured to point to where the tests are located and then registered with the Validmind framework under a namespace. Once registered, the framework will be able to identify content IDs in templates that are associated with the namespace and will be able to then load the tests matching those IDs using the test provider."
+                "Now that we have created a new test, how do we start making use of it in the ValidMind framework? This is where our new External Test Provider feature comes in. As users of the framework develop their own tests which will live outside of the framework source code, how will those tests get seamlessly plugged into the framework? The answer is through the use of a `ExternalTestProvider` class. We provide a test provider class that can load tests from a folder. Each can be configured to point to where the tests are located and then registered with the ValidMind framework under a namespace. Once registered, the framework will be able to identify content IDs in templates that are associated with the namespace and will be able to then load the tests matching those IDs using the test provider."
             ]
         },
         {
@@ -408,7 +408,7 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "### Set up the Validmind connection"
+                "### Set up the ValidMind connection"
             ]
         },
         {

--- a/notebooks/code_sharing/operational_deposit/operational_deposit_poc.ipynb
+++ b/notebooks/code_sharing/operational_deposit/operational_deposit_poc.ipynb
@@ -217,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Validmind objects\n"
+    "## ValidMind objects\n"
    ]
   },
   {

--- a/notebooks/how_to/run_tests/1_run_dataset_based_tests.ipynb
+++ b/notebooks/how_to/run_tests/1_run_dataset_based_tests.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Run dataset based tests\n",
     "\n",
-    "Use the Validmind Developer Framework's `run_test` function to run built-in or custom tests that take any dataset or model as input. These tests generate outputs in the form of text, tables, and images that get populated in model documentation.\n",
+    "Use the ValidMind Developer Framework's `run_test` function to run built-in or custom tests that take any dataset or model as input. These tests generate outputs in the form of text, tables, and images that get populated in model documentation.\n",
     "\n",
     "You'll learn how to:\n",
     "\n",

--- a/tests/test_validmind_tests_module.py
+++ b/tests/test_validmind_tests_module.py
@@ -1,5 +1,5 @@
 """
-Unit tests for Validmind tests module
+Unit tests for ValidMind tests module
 """
 import unittest
 from unittest import TestCase


### PR DESCRIPTION
## Internal Notes for Reviewers

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->
There were some cases where the proper noun form of "ValidMind" was not being followed, i.e. "Validmind". 

There were two cases where I didn't change it yet:
- In `run_unit_metrics.ipynb` because the text references a screenshot with the same misspelling:
![image](https://github.com/validmind/developer-framework/assets/143854391/2490f0b0-2639-48e7-bb22-11083c780dfd)

- In `LanguageDetection.py` because it is part of an error message script and I'm not sure I should mess with that.
![image](https://github.com/validmind/developer-framework/assets/143854391/ccfaadf2-1117-4ed1-be49-dbd343cce0ad)

## External Release Notes
<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->