### PR TITLE
[Quickstart] Fixed "Get your code snippet" header

### DIFF
--- a/notebooks/code_samples/quickstart_customer_churn_full_suite.ipynb
+++ b/notebooks/code_samples/quickstart_customer_churn_full_suite.ipynb
@@ -141,6 +141,7 @@
     "ValidMind generates a unique _code snippet_ for each registered model to connect with your developer environment. You initialize the client library with this code snippet, which ensures that your documentation and tests are uploaded to the correct model when you run the notebook.\n",
     "\n",
     "<a id='toc3_1_'></a>\n",
+    "\n",
     "### Get your code snippet\n",
     "\n",
     "1. In a browser, log into the [Platform UI](https://app.prod.validmind.ai).\n",
@@ -514,7 +515,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Internal Notes for Reviewers

### Quickstart for model documentation
I noticed that on our live site the "Get your code snippet" header under **Initialize the client library** doesn't render correctly. This is due to the fact that the anchor for that header does not have a line break after it:

| Current Rendered Page | Old Anchor in Notebook |
|---|---|
|<img width="1216" alt="Screenshot 2024-06-10 at 11 53 11 AM" src="https://github.com/validmind/developer-framework/assets/164545837/97265f7c-fb8a-46fb-9798-a180e449e40f">|![Screenshot 2024-06-10 at 12 01 30 PM](https://github.com/validmind/developer-framework/assets/164545837/74df88b7-4066-4c31-8049-867bb463064e)|

I added a line break after it and now it should render like this when pulled into the `documentation` repo:
<img width="1470" alt="Screenshot 2024-06-10 at 12 00 45 PM" src="https://github.com/validmind/developer-framework/assets/164545837/c49f55a7-0c0b-498b-8867-6abc16053320">

> @noosheenv If you're up for it, do you want to make a Story after this PR is approved and merged for this Sprint to pull the files into the `documentation` repo and do some testing to confirm that the notebooks render as expected? :) 