### PR TITLE
[SC-4949] Replace time series notebook in integration tests

### DIFF
--- a/scripts/run_e2e_notebooks.py
+++ b/scripts/run_e2e_notebooks.py
@@ -42,7 +42,7 @@ NOTEBOOKS_TO_RUN = [
         "path": "notebooks/code_samples/quickstart_customer_churn_full_suite.ipynb",
         "project": DEFAULT_PROJECT_ID,
     },
-    "notebooks/code_samples/time_series/tutorial_time_series_forecasting.ipynb",
+    "notebooks/code_samples/time_series/quickstart_time_series_full_suite.ipynb",
     # "notebooks/code_samples/regression/quickstart_regression_full_suite.ipynb",
     # TODO: fix the above when we have a regression template installed
     "notebooks/how_to/run_unit_metrics.ipynb",


### PR DESCRIPTION
## Internal Notes for Reviewers
Replace the deprecated `tutorial_time_series_forecasting.ipynb` with the new time series notebook `quickstart_time_series_full_suite.ipynb` in `run_e2e_notebooks.py`.

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->