### PR TITLE
John6797/dependency updates

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -29,31 +29,41 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'poetry'
+
+      # TODO: get the below to work so we can test that the built package installs correctly
+      # - name: Install Dependencies
+      #   run: poetry config virtualenvs.in-project true && poetry env use python3.11 && poetry install --all-extras
+
+      # - name: Build the package
+      #   run: poetry build
+
+      # - name: Remove Build Environment
+      #   run: rm -rf .venv
+
+      # - name: Setup Virtual Environment
+      #   run: python -m venv sdist-venv
+
+      # - name: Install Built Package
+      #   run: sdist-venv/bin/pip install --no-cache-dir "$(ls dist/validmind*.whl | head -n 1)[all]"
+
+      # - name: Install Additional Dependencies
+      #   run: sdist-venv/bin/pip install nbformat papermill jupyter
+
+      # - name: Create Jupyter Kernel
+      #   run: sdist-venv/bin/python -m ipykernel install --user --name sdist-venv
+
+      # - name: Integration Tests
+      #   run: sdist-venv/bin/python scripts/run_e2e_notebooks.py --kernel sdist-venv
+      #   env:
+      #     NOTEBOOK_RUNNER_DEFAULT_PROJECT_ID: ${{ secrets.NOTEBOOK_RUNNER_DEFAULT_PROJECT_ID }}
+      #     NOTEBOOK_RUNNER_API_KEY: ${{ secrets.NOTEBOOK_RUNNER_API_KEY }}
+      #     NOTEBOOK_RUNNER_API_SECRET: ${{ secrets.NOTEBOOK_RUNNER_API_SECRET }}
 
       - name: Install Dependencies
-        run: poetry config virtualenvs.in-project true && poetry env use python3.11 && poetry install --all-extras
-
-      - name: Build the package
-        run: poetry build
-
-      - name: Remove Build Environment
-        run: rm -rf .venv
-
-      - name: Setup Virtual Environment
-        run: python -m venv sdist-venv
-
-      - name: Install Built Package
-        run: sdist-venv/bin/pip install --no-cache-dir "$(ls dist/validmind*.whl | head -n 1)[all]"
-
-      - name: Install Additional Dependencies
-        run: sdist-venv/bin/pip install nbformat papermill jupyter
-
-      - name: Create Jupyter Kernel
-        run: sdist-venv/bin/python -m ipykernel install --user --name sdist-venv
+        run: poetry env use python3.11 && poetry install --all-extras
 
       - name: Integration Tests
-        run: sdist-venv/bin/python scripts/run_e2e_notebooks.py --kernel sdist-venv
+        run: poetry run python scripts/run_e2e_notebooks.py
         env:
           NOTEBOOK_RUNNER_DEFAULT_PROJECT_ID: ${{ secrets.NOTEBOOK_RUNNER_DEFAULT_PROJECT_ID }}
           NOTEBOOK_RUNNER_API_KEY: ${{ secrets.NOTEBOOK_RUNNER_API_KEY }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -4,11 +4,16 @@
 name: Integration Tests
 
 on:
+  # push:
+  #   branches:
+  #     - main
+  #     - prod
+  #     - release-v1
+
   push:
-    branches:
-      - main
-      - prod
-      - release-v1
+    branches: [main]
+  pull_request:
+    branches: ['*']
 
 permissions:
   contents: read
@@ -29,42 +34,30 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'poetry'
-
-      # TODO: get the below to work so we can test that the built package installs correctly
-      # - name: Install Dependencies
-      #   run: poetry config virtualenvs.in-project true && poetry env use python3.11 && poetry install --all-extras
-
-      # - name: Build the package
-      #   run: poetry build
-
-      # - name: Remove Build Environment
-      #   run: rm -rf .venv
-
-      # - name: Setup Virtual Environment
-      #   run: python -m venv sdist-venv
-
-      # - name: Install Built Package
-      #   run: sdist-venv/bin/pip install --no-cache-dir "$(ls dist/validmind*.whl | head -n 1)[all]"
-
-      # - name: Install Additional Dependencies
-      #   run: sdist-venv/bin/pip install nbformat papermill jupyter
-
-      # - name: Create Jupyter Kernel
-      #   run: sdist-venv/bin/python -m ipykernel install --user --name sdist-venv
-
-      # - name: Integration Tests
-      #   run: sdist-venv/bin/python scripts/run_e2e_notebooks.py --kernel sdist-venv
-      #   env:
-      #     NOTEBOOK_RUNNER_DEFAULT_PROJECT_ID: ${{ secrets.NOTEBOOK_RUNNER_DEFAULT_PROJECT_ID }}
-      #     NOTEBOOK_RUNNER_API_KEY: ${{ secrets.NOTEBOOK_RUNNER_API_KEY }}
-      #     NOTEBOOK_RUNNER_API_SECRET: ${{ secrets.NOTEBOOK_RUNNER_API_SECRET }}
 
       - name: Install Dependencies
-        run: poetry env use python3.11 && poetry install --all-extras
+        run: poetry config virtualenvs.in-project true && poetry env use python3.11 && poetry install --all-extras
+
+      - name: Build the package
+        run: poetry build
+
+      - name: Remove Build Environment
+        run: rm -rf .venv
+
+      - name: Setup Virtual Environment
+        run: python -m venv sdist-venv
+
+      - name: Install Built Package
+        run: sdist-venv/bin/pip install --no-cache-dir "$(ls dist/validmind*.whl | head -n 1)[all]"
+
+      - name: Install Additional Dependencies
+        run: sdist-venv/bin/pip install nbformat papermill jupyter
+
+      - name: Create Jupyter Kernel
+        run: sdist-venv/bin/python -m ipykernel install --user --name sdist-venv
 
       - name: Integration Tests
-        run: poetry run python scripts/run_e2e_notebooks.py
+        run: sdist-venv/bin/python scripts/run_e2e_notebooks.py --kernel sdist-venv
         env:
           NOTEBOOK_RUNNER_DEFAULT_PROJECT_ID: ${{ secrets.NOTEBOOK_RUNNER_DEFAULT_PROJECT_ID }}
           NOTEBOOK_RUNNER_API_KEY: ${{ secrets.NOTEBOOK_RUNNER_API_KEY }}

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -4,16 +4,11 @@
 name: Integration Tests
 
 on:
-  # push:
-  #   branches:
-  #     - main
-  #     - prod
-  #     - release-v1
-
   push:
-    branches: [main]
-  pull_request:
-    branches: ['*']
+    branches:
+      - main
+      - prod
+      - release-v1
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'poetry'
 
       # TODO: get the below to work so we can test that the built package installs correctly
       # - name: Install Dependencies


### PR DESCRIPTION
## Internal Notes for Reviewers

Don't use cache for integration tests since its not used and it eats up the disk space to where the validmind package cannot be installed in a separate directory (from the built package).

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `chore`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->