### PR TITLE
Updated the required Python versions for the Developer Intro .ipynb

### DIFF
--- a/notebooks/tutorials/intro_for_model_developers.ipynb
+++ b/notebooks/tutorials/intro_for_model_developers.ipynb
@@ -167,7 +167,7 @@
     "\n",
     "Please note the following recommended Python versions to use:\n",
     "\n",
-    "- Python 3.7 > x <= 3.11\n",
+    "- Python 3.8 <= x <= 3.11\n",
     "\n",
     "The client library provides Python support for the ValidMind Developer Framework. To install it run:\n"
    ]


### PR DESCRIPTION
## Internal Notes for Reviewers

> [As per the discussion in Slack](https://validmind.slack.com/archives/C04LL15THJA/p1718299479783419), I've updated the  "Please note the following recommended Python versions to use:" to `3.8 <= x <= 3.11`: https://github.com/validmind/developer-framework/blob/55aa529eb8b9d923fc1bea81e27fc2f32ec7814d/notebooks/tutorials/intro_for_model_developers.ipynb#L170
