### PR TITLE
Fixed broken links referring to nlp_and_llm instead of NLP_and_LLM

### DIFF
--- a/notebooks/how_to/use_dataset_model_objects.ipynb
+++ b/notebooks/how_to/use_dataset_model_objects.ipynb
@@ -849,7 +849,7 @@
     "\n",
     "- [Application scorecard demo](../code_samples/credit_risk/application_scorecard_demo.ipynb)\n",
     "- [Linear regression documentation demo](../code_samples/regression/quickstart_regression_full_suite.ipynb)\n",
-    "- [LLM model documentation demo](../code_samples/nlp_and_llm/foundation_models_integration_demo.ipynb)\n",
+    "- [LLM model documentation demo](../code_samples/NLP_and_LLM/foundation_models_integration_demo.ipynb)\n",
     "\n",
     "<a id='toc7_2_'></a>\n",
     "\n",

--- a/notebooks/tutorials/intro_for_model_developers.ipynb
+++ b/notebooks/tutorials/intro_for_model_developers.ipynb
@@ -1699,7 +1699,7 @@
     "\n",
     "- [Application scorecard demo](../code_samples/credit_risk/application_scorecard_demo.ipynb)\n",
     "- [Linear regression documentation demo](../code_samples/regression/quickstart_regression_full_suite.ipynb)\n",
-    "- [LLM model documentation demo](../code_samples/nlp_and_llm/foundation_models_integration_demo.ipynb)\n",
+    "- [LLM model documentation demo](../code_samples/NLP_and_LLM/foundation_models_integration_demo.ipynb)\n",
     "\n",
     "<a id='toc8_2_'></a>\n",
     "\n",


### PR DESCRIPTION
## Internal Notes for Reviewers
There were two references to `notebooks/code_samples/nlp_and_llm/foundation_models_integration_demo.ipynb` that were broken because the folder is named `NLP_and_LLM`. 

Changed the references to this: `notebooks/code_samples/NLP_and_LLM/foundation_models_integration_demo.ipynb` and the links work now!! Woohoo!

The notebooks affected are: 
`notebooks/how_to/use_dataset_model_objects.ipynb`
`notebooks/tutorials/intro_for_model_developers.ipynb`

For reference, both links were in this section of the notebooks (LLM model documentation demo):
<img width="377" alt="image" src="https://github.com/validmind/developer-framework/assets/143854391/7b2439d2-f091-44d4-8fc6-03e71cefdbe3">

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `chore`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->