### PR TITLE
Missed some Learn more ... Model documentation links

### DIFF
--- a/notebooks/code_samples/custom_tests/implement_custom_tests.ipynb
+++ b/notebooks/code_samples/custom_tests/implement_custom_tests.ipynb
@@ -841,7 +841,7 @@
     "\n",
     "2. Click and expand the **Model Development** section.\n",
     "\n",
-    "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+    "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
     "\n",
     "<a id='toc11_2_'></a>\n",
     "\n",

--- a/notebooks/code_samples/custom_tests/integrate_external_test_providers.ipynb
+++ b/notebooks/code_samples/custom_tests/integrate_external_test_providers.ipynb
@@ -817,7 +817,7 @@
         "\n",
         "2. Click and expand the **Model Development** section.\n",
         "\n",
-        "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+        "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
         "\n",
         "<a id='toc10_2_'></a>\n",
         "\n",

--- a/notebooks/code_samples/customization/customizing_tests_with_output_templates.ipynb
+++ b/notebooks/code_samples/customization/customizing_tests_with_output_templates.ipynb
@@ -705,7 +705,7 @@
         "\n",
         "2. Click and expand the **Model Development** section.\n",
         "\n",
-        "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+        "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
         "\n",
         "<a id='toc7_2_'></a>\n",
         "\n",

--- a/notebooks/code_samples/nlp_and_llm/prompt_validation_demo.ipynb
+++ b/notebooks/code_samples/nlp_and_llm/prompt_validation_demo.ipynb
@@ -397,7 +397,7 @@
                 "\n",
                 "2. Click and expand the **Model Development** section.\n",
                 "\n",
-                "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+                "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
                 "\n",
                 "<a id='toc5_2_'></a>\n",
                 "\n",

--- a/notebooks/code_samples/quickstart_customer_churn_full_suite.ipynb
+++ b/notebooks/code_samples/quickstart_customer_churn_full_suite.ipynb
@@ -478,7 +478,7 @@
     "\n",
     "2. Click and expand the **Model Development** section.\n",
     "\n",
-    "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+    "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
     "\n",
     "<a id='toc7_2_'></a>\n",
     "\n",

--- a/notebooks/code_samples/time_series/quickstart_time_series_full_suite.ipynb
+++ b/notebooks/code_samples/time_series/quickstart_time_series_full_suite.ipynb
@@ -600,7 +600,7 @@
     "\n",
     "2. Click and expand the **Model Development** section.\n",
     "\n",
-    "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+    "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
     "\n",
     "<a id='toc7_2_'></a>\n",
     "\n",

--- a/notebooks/how_to/configure_dataset_features.ipynb
+++ b/notebooks/how_to/configure_dataset_features.ipynb
@@ -341,7 +341,7 @@
         "\n",
         "2. Click and expand the **Model Development** section.\n",
         "\n",
-        "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+        "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
         "\n",
         "<a id='toc6_2_'></a>\n",
         "\n",

--- a/notebooks/how_to/document_multiple_results_for_the_same_test.ipynb
+++ b/notebooks/how_to/document_multiple_results_for_the_same_test.ipynb
@@ -461,7 +461,7 @@
     "\n",
     "   You can now see the skewness tests results of training and test datasets in the `Data Preparation` section.\n",
     "\n",
-    "From here, you can also make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+    "From here, you can also make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
     "\n",
     "<a id='toc8_2_'></a>\n",
     "\n",

--- a/notebooks/how_to/load_datasets_predictions.ipynb
+++ b/notebooks/how_to/load_datasets_predictions.ipynb
@@ -721,7 +721,7 @@
                 "\n",
                 "2. Click and expand the **Model Development** section.\n",
                 "\n",
-                "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+                "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
                 "\n",
                 "<a id='toc9_2_'></a>\n",
                 "\n",

--- a/notebooks/how_to/run_documentation_sections.ipynb
+++ b/notebooks/how_to/run_documentation_sections.ipynb
@@ -438,7 +438,7 @@
     "\n",
     "2. Click and expand the **Model Development** section.\n",
     "\n",
-    "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+    "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
     "\n",
     "<a id='toc10_2_'></a>\n",
     "\n",

--- a/notebooks/how_to/run_documentation_tests_with_config.ipynb
+++ b/notebooks/how_to/run_documentation_tests_with_config.ipynb
@@ -570,7 +570,7 @@
                 "\n",
                 "2. Click and expand the **Model Development** section.\n",
                 "\n",
-                "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+                "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
                 "\n",
                 "<a id='toc10_2_'></a>\n",
                 "\n",

--- a/notebooks/how_to/run_tests_that_require_multiple_datasets.ipynb
+++ b/notebooks/how_to/run_tests_that_require_multiple_datasets.ipynb
@@ -422,7 +422,7 @@
                 "\n",
                 "2. Click and expand the **Model Development** section.\n",
                 "\n",
-                "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+                "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
                 "\n",
                 "<a id='toc9_2_'></a>\n",
                 "\n",

--- a/notebooks/how_to/run_unit_metrics.ipynb
+++ b/notebooks/how_to/run_unit_metrics.ipynb
@@ -744,7 +744,7 @@
     "\n",
     "2. Click and expand the **Model Development** section.\n",
     "\n",
-    "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)\n",
+    "What you see is the full draft of your model documentation in a more easily consumable version. From here, you can make qualitative edits to model documentation, view guidelines, collaborate with validators, and submit your model documentation for approval when it's ready. [Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)\n",
     "\n",
     "<a id='toc10_2_'></a>\n",
     "\n",


### PR DESCRIPTION
## Internal Notes for Reviewers

Somehow missed a `Learn more` link out to the documentation on model documentation, so I've quickly fixed that and tested the links to make sure the notebook still renders fine.

| Old Link | New Link |
|---|---|
| `[Learn more ...](https://docs.validmind.ai/guide/working-with-model-documentation.html)` | `[Learn more ...](https://docs.validmind.ai/guide/model-documentation/working-with-model-documentation.html)` |