### PR TITLE
[SC 5587] Initial support ongoing monitoring through header

### DIFF
--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -72,6 +72,7 @@ class TestAPIClient(unittest.TestCase):
                 "X-API-KEY": os.environ["VM_API_KEY"],
                 "X-API-SECRET": os.environ["VM_API_SECRET"],
                 "X-PROJECT-CUID": os.environ["VM_API_MODEL"],
+                "X-MONITORING": "False",
             },
         )
 
@@ -135,6 +136,8 @@ class TestAPIClient(unittest.TestCase):
                 "X-API-KEY": os.environ["VM_API_KEY"],
                 "X-API-SECRET": os.environ["VM_API_SECRET"],
                 "X-PROJECT-CUID": os.environ["VM_API_MODEL"],
+                "X-MONITORING": "False",
+
             },
         )
 

--- a/validmind/api_client.py
+++ b/validmind/api_client.py
@@ -34,7 +34,7 @@ _api_secret = os.getenv("VM_API_SECRET")
 _api_host = os.getenv("VM_API_HOST")
 _model_cuid = os.getenv("VM_API_MODEL")
 _run_cuid = os.getenv("VM_RUN_CUID")
-_monitoring = "False"
+_monitoring = False
 
 __api_session: aiohttp.ClientSession = None
 
@@ -85,7 +85,7 @@ def init(
     api_secret: Optional[str] = None,
     api_host: Optional[str] = None,
     model: Optional[str] = None,
-    monitoring="False",
+    monitoring=False,
 ):
     """
     Initializes the API client instances and calls the /ping endpoint to ensure
@@ -166,7 +166,7 @@ def __ping() -> Dict[str, Any]:
             "X-API-KEY": _api_key,
             "X-API-SECRET": _api_secret,
             "X-PROJECT-CUID": _model_cuid,
-            "X-MONITORING": _monitoring,
+            "X-MONITORING": str(_monitoring),
         },
     )
     if r.status_code != 200:

--- a/validmind/api_client.py
+++ b/validmind/api_client.py
@@ -34,6 +34,7 @@ _api_secret = os.getenv("VM_API_SECRET")
 _api_host = os.getenv("VM_API_HOST")
 _model_cuid = os.getenv("VM_API_MODEL")
 _run_cuid = os.getenv("VM_RUN_CUID")
+_monitoring = "False"
 
 __api_session: aiohttp.ClientSession = None
 
@@ -57,6 +58,7 @@ def get_api_config() -> Dict[str, Optional[str]]:
         "VM_API_HOST": _api_host,
         "VM_API_MODEL": _model_cuid,
         "VM_RUN_CUID": _run_cuid,
+        "X-MONITORING": _monitoring
     }
 
 
@@ -73,6 +75,7 @@ def get_api_headers() -> Dict[str, str]:
         "X-API-KEY": _api_key,
         "X-API-SECRET": _api_secret,
         "X-PROJECT-CUID": _model_cuid,
+        "X-MONITORING": _monitoring
     }
 
 
@@ -82,6 +85,7 @@ def init(
     api_secret: Optional[str] = None,
     api_host: Optional[str] = None,
     model: Optional[str] = None,
+    monitoring="False",
 ):
     """
     Initializes the API client instances and calls the /ping endpoint to ensure
@@ -100,7 +104,7 @@ def init(
     Raises:
         ValueError: If the API key and secret are not provided
     """
-    global _api_key, _api_secret, _api_host, _run_cuid, _model_cuid
+    global _api_key, _api_secret, _api_host, _run_cuid, _model_cuid, _monitoring
 
     if api_key == "...":
         # special case to detect when running a notebook with the standard init snippet
@@ -124,6 +128,8 @@ def init(
     )
 
     _run_cuid = os.getenv("VM_RUN_CUID", None)
+
+    _monitoring = monitoring
 
     try:
         __ping()
@@ -159,6 +165,7 @@ def __ping() -> Dict[str, Any]:
             "X-API-KEY": _api_key,
             "X-API-SECRET": _api_secret,
             "X-PROJECT-CUID": _model_cuid,
+            "X-MONITORING": _monitoring,
         },
     )
     if r.status_code != 200:

--- a/validmind/api_client.py
+++ b/validmind/api_client.py
@@ -58,7 +58,7 @@ def get_api_config() -> Dict[str, Optional[str]]:
         "VM_API_HOST": _api_host,
         "VM_API_MODEL": _model_cuid,
         "VM_RUN_CUID": _run_cuid,
-        "X-MONITORING": _monitoring
+        "X-MONITORING": _monitoring,
     }
 
 
@@ -75,7 +75,7 @@ def get_api_headers() -> Dict[str, str]:
         "X-API-KEY": _api_key,
         "X-API-SECRET": _api_secret,
         "X-PROJECT-CUID": _model_cuid,
-        "X-MONITORING": _monitoring
+        "X-MONITORING": _monitoring,
     }
 
 
@@ -100,6 +100,7 @@ def init(
         api_key (str, optional): The API key. Defaults to None.
         api_secret (str, optional): The API secret. Defaults to None.
         api_host (str, optional): The API host. Defaults to None.
+        monitoring (str, optional): The ongoing monitoring flag. Defaults to False.
 
     Raises:
         ValueError: If the API key and secret are not provided


### PR DESCRIPTION
We would like to support new content type, monitoring for tests so that we can differentiate between document tests and monitoring tests. These tests can be shown in the monitoring template.

## Internal Notes for Reviewers
 - Pass a `monitoring` parameter in the `vm.init()` method so that tests results to go to a different "bucket". By default value is `False`
 - Tests run after that should go into in `monitoring` bucket that will be handled in the backend if the `X-MONITORING`  header  is `True`.

```python
import validmind as vm
vm.init(
  api_host = "....",
  api_key = "....",
  api_secret = "....",
  project = "...",
  monitoring=True
)
```
## External Notes for Reviewers
 - Pass a `monitoring` parameter in the `vm.init()` method so that tests results to go to a different "bucket". By default value is `False`
 - Tests run after that should go into in `monitoring` bucket that will be handled in the backend if the `X-MONITORING`  header  is `True`.
 
```python
import validmind as vm
vm.init(
  api_host = "....",
  api_key = "....",
  api_secret = "....",
  project = "...",
  monitoring=True
)
```