### PR TITLE
fix: use dict instead of df for test result in robustness diagnosis

### DIFF
--- a/validmind/tests/model_validation/sklearn/RobustnessDiagnosis.py
+++ b/validmind/tests/model_validation/sklearn/RobustnessDiagnosis.py
@@ -376,4 +376,4 @@ class RobustnessDiagnosis(ThresholdTest):
         for test_result in self.result.test_results.results:
             assert "values" in test_result.__dict__
             assert "passed" in test_result.__dict__
-            assert isinstance(test_result.values, dict)
+            assert isinstance(test_result.values, list)

--- a/validmind/tests/model_validation/sklearn/RobustnessDiagnosis.py
+++ b/validmind/tests/model_validation/sklearn/RobustnessDiagnosis.py
@@ -376,4 +376,4 @@ class RobustnessDiagnosis(ThresholdTest):
         for test_result in self.result.test_results.results:
             assert "values" in test_result.__dict__
             assert "passed" in test_result.__dict__
-            assert isinstance(test_result.values, pd.DataFrame)
+            assert isinstance(test_result.values, dict)

--- a/validmind/tests/model_validation/sklearn/RobustnessDiagnosis.py
+++ b/validmind/tests/model_validation/sklearn/RobustnessDiagnosis.py
@@ -342,7 +342,7 @@ class RobustnessDiagnosis(ThresholdTest):
                 ThresholdTestResult(
                     test_name=self.params["metric"],
                     passed=results["Passed"].all(),
-                    values=results,
+                    values=results.to_dict(orient="records"),
                 )
             ],
             figures=[


### PR DESCRIPTION
## Internal Notes for Reviewers

My last PR (https://github.com/validmind/developer-framework/pull/169) had a bug that only appears when you try to log the test result. Its due to the test result returning a dataframe instead of a dictionary.

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `chore`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->