### PR TITLE
Fix: Clean Docs Build Folder Before Regenerating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ test-integration:
 	poetry run python scripts/run_e2e_notebooks.py
 
 docs:
+	rm -rf docs/_build
 	poetry run pdoc validmind -d google -t docs/templates --no-show-source --logo https://vmai.s3.us-west-1.amazonaws.com/vm-logo.svg --favicon https://vmai.s3.us-west-1.amazonaws.com/favicon.ico -o docs/_build
 
 docs-serve:


### PR DESCRIPTION
## Internal Notes for Reviewers

Quick fix for a bunch of deleted tests and such that still exist in the docs stite. This updates the `make docs` command to remove the docs build folder before regenerating with pdoc. This will ensure that deleted tests don't get left in the docs. Tested this locally but removed the docs updates to let GH actions handle it separately.

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `chore`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->