### PR TITLE
Add parameter grid support in the comparison tests functionality

### DIFF
--- a/notebooks/code_samples/regression/quickstart_regression_full_suite.ipynb
+++ b/notebooks/code_samples/regression/quickstart_regression_full_suite.ipynb
@@ -59,23 +59,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "id": "6G5-kHOZ7YWk"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[33mWARNING: visions 0.7.5 does not provide the extra 'type-image-path'\u001b[0m\u001b[33m\n",
-      "\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.2\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install -q validmind"
    ]
@@ -106,21 +94,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "id": "5hqGn9jHSPc2"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-10-01 14:12:38,343 - INFO(validmind.api_client): 🎉 Connected to ValidMind!\n",
-      "📊 Model: [Int. Tests] Regression (ID: cltnl7swd000s1omg6t4ul5bn)\n",
-      "📁 Document Type: model_documentation\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Replace with your code snippet\n",
     "\n",
@@ -184,80 +162,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-10-01 14:12:38,920 - ERROR(validmind.tests.load): Unable to load test validmind.model_validation.sklearn.RegressionModelsPerformanceComparison. No module named 'validmind.tests.model_validation.sklearn.RegressionModelsPerformanceComparison'\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3cde800fc6154d5b892343fc7de273f9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Accordion(children=(Accordion(children=(HTML(value='<p>Empty Section</p>'), Accordion(children=(HTML(value='<p…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<script defer type=\"module\">\n",
-       "import hljs from 'https://unpkg.com/@highlightjs/cdn-assets@11.9.0/es/highlight.min.js';\n",
-       "import python from 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/es/languages/python.min.js';\n",
-       "\n",
-       "hljs.registerLanguage('python', python);\n",
-       "hljs.highlightAll();\n",
-       "</script>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<script>\n",
-       "window.MathJax = {\n",
-       "    tex2jax: {\n",
-       "        inlineMath: [['$', '$'], ['\\\\(', '\\\\)']],\n",
-       "        displayMath: [['$$', '$$'], ['\\[', '\\]']],\n",
-       "        processEscapes: true,\n",
-       "        skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],\n",
-       "        ignoreClass: \".*\",\n",
-       "        processClass: \"math\"\n",
-       "    }\n",
-       "};\n",
-       "setTimeout(function () {\n",
-       "    var script = document.createElement('script');\n",
-       "    script.type = 'text/javascript';\n",
-       "    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS_HTML';\n",
-       "    document.head.appendChild(script);\n",
-       "}, 300);\n",
-       "</script>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "vm.preview_template()"
    ]
@@ -288,111 +195,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loaded demo dataset with: \n",
-      "\n",
-      "\t• Target column: 'MedHouseVal\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>HouseAge</th>\n",
-       "      <th>AveRooms</th>\n",
-       "      <th>AveBedrms</th>\n",
-       "      <th>Population</th>\n",
-       "      <th>AveOccup</th>\n",
-       "      <th>MedHouseVal</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>41.0</td>\n",
-       "      <td>6.984127</td>\n",
-       "      <td>1.023810</td>\n",
-       "      <td>322.0</td>\n",
-       "      <td>2.555556</td>\n",
-       "      <td>4.526</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>21.0</td>\n",
-       "      <td>6.238137</td>\n",
-       "      <td>0.971880</td>\n",
-       "      <td>2401.0</td>\n",
-       "      <td>2.109842</td>\n",
-       "      <td>3.585</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>52.0</td>\n",
-       "      <td>8.288136</td>\n",
-       "      <td>1.073446</td>\n",
-       "      <td>496.0</td>\n",
-       "      <td>2.802260</td>\n",
-       "      <td>3.521</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>52.0</td>\n",
-       "      <td>5.817352</td>\n",
-       "      <td>1.073059</td>\n",
-       "      <td>558.0</td>\n",
-       "      <td>2.547945</td>\n",
-       "      <td>3.413</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>52.0</td>\n",
-       "      <td>6.281853</td>\n",
-       "      <td>1.081081</td>\n",
-       "      <td>565.0</td>\n",
-       "      <td>2.181467</td>\n",
-       "      <td>3.422</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   HouseAge  AveRooms  AveBedrms  Population  AveOccup  MedHouseVal\n",
-       "0      41.0  6.984127   1.023810       322.0  2.555556        4.526\n",
-       "1      21.0  6.238137   0.971880      2401.0  2.109842        3.585\n",
-       "2      52.0  8.288136   1.073446       496.0  2.802260        3.521\n",
-       "3      52.0  5.817352   1.073059       558.0  2.547945        3.413\n",
-       "4      52.0  6.281853   1.081081       565.0  2.181467        3.422"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Import the sample dataset from the library\n",
     "\n",
@@ -459,20 +264,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "R² of Support Vector Regressor on training set: 0.918\n",
-      "R² of Support Vector Regressor on test set: 0.407\n",
-      "R² of Support Gradient Boosting Regressor on training set: 0.508\n",
-      "R² of Support Gradient Boosting Regressor on test set: 0.439\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "scale = False\n",
     "if scale:\n",
@@ -521,21 +315,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "id": "ShiOFS7bSPc7"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-10-01 14:12:45,195 - INFO(validmind.client): Pandas dataset detected. Initializing VM Dataset instance...\n",
-      "2024-10-01 14:12:46,260 - INFO(validmind.client): Pandas dataset detected. Initializing VM Dataset instance...\n",
-      "2024-10-01 14:12:46,460 - INFO(validmind.client): Pandas dataset detected. Initializing VM Dataset instance...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "vm_raw_dataset = vm.init_dataset(\n",
     "    dataset=raw_df,\n",
@@ -593,44 +377,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-10-01 14:12:47,856 - INFO(validmind.vm_models.dataset.utils): Running predict_proba()... This may take a while\n",
-      "2024-10-01 14:12:47,856 - INFO(validmind.vm_models.dataset.utils): Not running predict_proba() for unsupported models.\n",
-      "2024-10-01 14:12:47,857 - INFO(validmind.vm_models.dataset.utils): Running predict()... This may take a while\n",
-      "/Users/anilsorathiya/Library/Caches/pypoetry/virtualenvs/validmind-1QuffXMV-py3.10/lib/python3.10/site-packages/sklearn/base.py:465: UserWarning: X does not have valid feature names, but RandomForestRegressor was fitted with feature names\n",
-      "  warnings.warn(\n",
-      "2024-10-01 14:12:48,055 - INFO(validmind.vm_models.dataset.utils): Done running predict()\n",
-      "2024-10-01 14:12:48,056 - INFO(validmind.vm_models.dataset.dataset): No probabilities computed or provided. Not adding probability column to the dataset.\n",
-      "2024-10-01 14:12:48,057 - INFO(validmind.vm_models.dataset.utils): Running predict_proba()... This may take a while\n",
-      "2024-10-01 14:12:48,057 - INFO(validmind.vm_models.dataset.utils): Not running predict_proba() for unsupported models.\n",
-      "2024-10-01 14:12:48,057 - INFO(validmind.vm_models.dataset.utils): Running predict()... This may take a while\n",
-      "/Users/anilsorathiya/Library/Caches/pypoetry/virtualenvs/validmind-1QuffXMV-py3.10/lib/python3.10/site-packages/sklearn/base.py:465: UserWarning: X does not have valid feature names, but GradientBoostingRegressor was fitted with feature names\n",
-      "  warnings.warn(\n",
-      "2024-10-01 14:12:48,073 - INFO(validmind.vm_models.dataset.utils): Done running predict()\n",
-      "2024-10-01 14:12:48,073 - INFO(validmind.vm_models.dataset.dataset): No probabilities computed or provided. Not adding probability column to the dataset.\n",
-      "2024-10-01 14:12:48,074 - INFO(validmind.vm_models.dataset.utils): Running predict_proba()... This may take a while\n",
-      "2024-10-01 14:12:48,074 - INFO(validmind.vm_models.dataset.utils): Not running predict_proba() for unsupported models.\n",
-      "2024-10-01 14:12:48,075 - INFO(validmind.vm_models.dataset.utils): Running predict()... This may take a while\n",
-      "/Users/anilsorathiya/Library/Caches/pypoetry/virtualenvs/validmind-1QuffXMV-py3.10/lib/python3.10/site-packages/sklearn/base.py:465: UserWarning: X does not have valid feature names, but RandomForestRegressor was fitted with feature names\n",
-      "  warnings.warn(\n",
-      "2024-10-01 14:12:48,142 - INFO(validmind.vm_models.dataset.utils): Done running predict()\n",
-      "2024-10-01 14:12:48,143 - INFO(validmind.vm_models.dataset.dataset): No probabilities computed or provided. Not adding probability column to the dataset.\n",
-      "2024-10-01 14:12:48,144 - INFO(validmind.vm_models.dataset.utils): Running predict_proba()... This may take a while\n",
-      "2024-10-01 14:12:48,144 - INFO(validmind.vm_models.dataset.utils): Not running predict_proba() for unsupported models.\n",
-      "2024-10-01 14:12:48,144 - INFO(validmind.vm_models.dataset.utils): Running predict()... This may take a while\n",
-      "/Users/anilsorathiya/Library/Caches/pypoetry/virtualenvs/validmind-1QuffXMV-py3.10/lib/python3.10/site-packages/sklearn/base.py:465: UserWarning: X does not have valid feature names, but GradientBoostingRegressor was fitted with feature names\n",
-      "  warnings.warn(\n",
-      "2024-10-01 14:12:48,150 - INFO(validmind.vm_models.dataset.utils): Done running predict()\n",
-      "2024-10-01 14:12:48,151 - INFO(validmind.vm_models.dataset.dataset): No probabilities computed or provided. Not adding probability column to the dataset.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "vm_train_ds.assign_predictions(\n",
     "    model=vm_model,\n",
@@ -669,96 +418,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "id": "NgzKVN_gSPc8"
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2024-10-01 14:12:48,156 - ERROR(validmind.tests.load): Unable to load test validmind.model_validation.sklearn.RegressionModelsPerformanceComparison. No module named 'validmind.tests.model_validation.sklearn.RegressionModelsPerformanceComparison'\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7cf4d15ee285465eb6f56ce9fcb3723b",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(Label(value='Running test suite...'), IntProgress(value=0, max=32)))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e40b14cb083d4666a54a077e8d32b526",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(HTML(value='<h2>Test Suite Results: <i style=\"color: #DE257E\">Regression V1</i></h2><hr>'), HTM…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<script defer type=\"module\">\n",
-       "import hljs from 'https://unpkg.com/@highlightjs/cdn-assets@11.9.0/es/highlight.min.js';\n",
-       "import python from 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/es/languages/python.min.js';\n",
-       "\n",
-       "hljs.registerLanguage('python', python);\n",
-       "hljs.highlightAll();\n",
-       "</script>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<script>\n",
-       "window.MathJax = {\n",
-       "    tex2jax: {\n",
-       "        inlineMath: [['$', '$'], ['\\\\(', '\\\\)']],\n",
-       "        displayMath: [['$$', '$$'], ['\\[', '\\]']],\n",
-       "        processEscapes: true,\n",
-       "        skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],\n",
-       "        ignoreClass: \".*\",\n",
-       "        processClass: \"math\"\n",
-       "    }\n",
-       "};\n",
-       "setTimeout(function () {\n",
-       "    var script = document.createElement('script');\n",
-       "    script.type = 'text/javascript';\n",
-       "    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS_HTML';\n",
-       "    document.head.appendChild(script);\n",
-       "}, 300);\n",
-       "</script>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "full_suite = vm.run_documentation_tests(\n",
     "    inputs={\n",

--- a/notebooks/code_samples/regression/quickstart_regression_full_suite.ipynb
+++ b/notebooks/code_samples/regression/quickstart_regression_full_suite.ipynb
@@ -59,11 +59,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "id": "6G5-kHOZ7YWk"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[33mWARNING: visions 0.7.5 does not provide the extra 'type-image-path'\u001b[0m\u001b[33m\n",
+      "\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.3.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m24.2\u001b[0m\n",
+      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
+     ]
+    }
+   ],
    "source": [
     "%pip install -q validmind"
    ]
@@ -94,22 +106,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "id": "5hqGn9jHSPc2"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-10-01 14:12:38,343 - INFO(validmind.api_client): 🎉 Connected to ValidMind!\n",
+      "📊 Model: [Int. Tests] Regression (ID: cltnl7swd000s1omg6t4ul5bn)\n",
+      "📁 Document Type: model_documentation\n"
+     ]
+    }
+   ],
    "source": [
     "# Replace with your code snippet\n",
     "\n",
     "import validmind as vm\n",
     "\n",
+    "\n",
+    "import validmind as vm\n",
+    "\n",
     "vm.init(\n",
-    "    api_host=\"https://api.prod.validmind.ai/api/v1/tracking\",\n",
-    "    api_key=\"...\",\n",
-    "    api_secret=\"...\",\n",
-    "    model=\"...\"\n",
-    ")"
+    "  api_host = \"...\",\n",
+    "  api_key = \"...\",\n",
+    "  api_secret = \"...\",\n",
+    "  project = \"...\"\n",
+    ")\n",
+    "\n",
+    "\n",
+    "import logging\n",
+    "import sys\n",
+    "import site\n",
+    "\n",
+    "logger = logging.getLogger()\n",
+    "\n",
+    "# Print the path to the current Python interpreter\n",
+    "logger.info(\"Python executable path: \" + sys.executable)\n",
+    "\n",
+    "# Print the path to the site-packages directory\n",
+    "logger.info(\"Site-packages path: \" + str(site.getsitepackages()))\n"
    ]
   },
   {
@@ -123,7 +161,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,9 +184,80 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-10-01 14:12:38,920 - ERROR(validmind.tests.load): Unable to load test validmind.model_validation.sklearn.RegressionModelsPerformanceComparison. No module named 'validmind.tests.model_validation.sklearn.RegressionModelsPerformanceComparison'\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3cde800fc6154d5b892343fc7de273f9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Accordion(children=(Accordion(children=(HTML(value='<p>Empty Section</p>'), Accordion(children=(HTML(value='<p…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<script defer type=\"module\">\n",
+       "import hljs from 'https://unpkg.com/@highlightjs/cdn-assets@11.9.0/es/highlight.min.js';\n",
+       "import python from 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/es/languages/python.min.js';\n",
+       "\n",
+       "hljs.registerLanguage('python', python);\n",
+       "hljs.highlightAll();\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<script>\n",
+       "window.MathJax = {\n",
+       "    tex2jax: {\n",
+       "        inlineMath: [['$', '$'], ['\\\\(', '\\\\)']],\n",
+       "        displayMath: [['$$', '$$'], ['\\[', '\\]']],\n",
+       "        processEscapes: true,\n",
+       "        skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],\n",
+       "        ignoreClass: \".*\",\n",
+       "        processClass: \"math\"\n",
+       "    }\n",
+       "};\n",
+       "setTimeout(function () {\n",
+       "    var script = document.createElement('script');\n",
+       "    script.type = 'text/javascript';\n",
+       "    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS_HTML';\n",
+       "    document.head.appendChild(script);\n",
+       "}, 300);\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "vm.preview_template()"
    ]
@@ -179,9 +288,111 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded demo dataset with: \n",
+      "\n",
+      "\t• Target column: 'MedHouseVal\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>HouseAge</th>\n",
+       "      <th>AveRooms</th>\n",
+       "      <th>AveBedrms</th>\n",
+       "      <th>Population</th>\n",
+       "      <th>AveOccup</th>\n",
+       "      <th>MedHouseVal</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>41.0</td>\n",
+       "      <td>6.984127</td>\n",
+       "      <td>1.023810</td>\n",
+       "      <td>322.0</td>\n",
+       "      <td>2.555556</td>\n",
+       "      <td>4.526</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>21.0</td>\n",
+       "      <td>6.238137</td>\n",
+       "      <td>0.971880</td>\n",
+       "      <td>2401.0</td>\n",
+       "      <td>2.109842</td>\n",
+       "      <td>3.585</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>52.0</td>\n",
+       "      <td>8.288136</td>\n",
+       "      <td>1.073446</td>\n",
+       "      <td>496.0</td>\n",
+       "      <td>2.802260</td>\n",
+       "      <td>3.521</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>52.0</td>\n",
+       "      <td>5.817352</td>\n",
+       "      <td>1.073059</td>\n",
+       "      <td>558.0</td>\n",
+       "      <td>2.547945</td>\n",
+       "      <td>3.413</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>52.0</td>\n",
+       "      <td>6.281853</td>\n",
+       "      <td>1.081081</td>\n",
+       "      <td>565.0</td>\n",
+       "      <td>2.181467</td>\n",
+       "      <td>3.422</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   HouseAge  AveRooms  AveBedrms  Population  AveOccup  MedHouseVal\n",
+       "0      41.0  6.984127   1.023810       322.0  2.555556        4.526\n",
+       "1      21.0  6.238137   0.971880      2401.0  2.109842        3.585\n",
+       "2      52.0  8.288136   1.073446       496.0  2.802260        3.521\n",
+       "3      52.0  5.817352   1.073059       558.0  2.547945        3.413\n",
+       "4      52.0  6.281853   1.081081       565.0  2.181467        3.422"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Import the sample dataset from the library\n",
     "\n",
@@ -225,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "id": "PMeDVcpsSPc7"
    },
@@ -248,9 +459,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "R² of Support Vector Regressor on training set: 0.918\n",
+      "R² of Support Vector Regressor on test set: 0.407\n",
+      "R² of Support Gradient Boosting Regressor on training set: 0.508\n",
+      "R² of Support Gradient Boosting Regressor on test set: 0.439\n"
+     ]
+    }
+   ],
    "source": [
     "scale = False\n",
     "if scale:\n",
@@ -299,11 +521,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "id": "ShiOFS7bSPc7"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-10-01 14:12:45,195 - INFO(validmind.client): Pandas dataset detected. Initializing VM Dataset instance...\n",
+      "2024-10-01 14:12:46,260 - INFO(validmind.client): Pandas dataset detected. Initializing VM Dataset instance...\n",
+      "2024-10-01 14:12:46,460 - INFO(validmind.client): Pandas dataset detected. Initializing VM Dataset instance...\n"
+     ]
+    }
+   ],
    "source": [
     "vm_raw_dataset = vm.init_dataset(\n",
     "    dataset=raw_df,\n",
@@ -334,7 +566,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "id": "wE0OckXjSPc7"
    },
@@ -361,9 +593,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-10-01 14:12:47,856 - INFO(validmind.vm_models.dataset.utils): Running predict_proba()... This may take a while\n",
+      "2024-10-01 14:12:47,856 - INFO(validmind.vm_models.dataset.utils): Not running predict_proba() for unsupported models.\n",
+      "2024-10-01 14:12:47,857 - INFO(validmind.vm_models.dataset.utils): Running predict()... This may take a while\n",
+      "/Users/anilsorathiya/Library/Caches/pypoetry/virtualenvs/validmind-1QuffXMV-py3.10/lib/python3.10/site-packages/sklearn/base.py:465: UserWarning: X does not have valid feature names, but RandomForestRegressor was fitted with feature names\n",
+      "  warnings.warn(\n",
+      "2024-10-01 14:12:48,055 - INFO(validmind.vm_models.dataset.utils): Done running predict()\n",
+      "2024-10-01 14:12:48,056 - INFO(validmind.vm_models.dataset.dataset): No probabilities computed or provided. Not adding probability column to the dataset.\n",
+      "2024-10-01 14:12:48,057 - INFO(validmind.vm_models.dataset.utils): Running predict_proba()... This may take a while\n",
+      "2024-10-01 14:12:48,057 - INFO(validmind.vm_models.dataset.utils): Not running predict_proba() for unsupported models.\n",
+      "2024-10-01 14:12:48,057 - INFO(validmind.vm_models.dataset.utils): Running predict()... This may take a while\n",
+      "/Users/anilsorathiya/Library/Caches/pypoetry/virtualenvs/validmind-1QuffXMV-py3.10/lib/python3.10/site-packages/sklearn/base.py:465: UserWarning: X does not have valid feature names, but GradientBoostingRegressor was fitted with feature names\n",
+      "  warnings.warn(\n",
+      "2024-10-01 14:12:48,073 - INFO(validmind.vm_models.dataset.utils): Done running predict()\n",
+      "2024-10-01 14:12:48,073 - INFO(validmind.vm_models.dataset.dataset): No probabilities computed or provided. Not adding probability column to the dataset.\n",
+      "2024-10-01 14:12:48,074 - INFO(validmind.vm_models.dataset.utils): Running predict_proba()... This may take a while\n",
+      "2024-10-01 14:12:48,074 - INFO(validmind.vm_models.dataset.utils): Not running predict_proba() for unsupported models.\n",
+      "2024-10-01 14:12:48,075 - INFO(validmind.vm_models.dataset.utils): Running predict()... This may take a while\n",
+      "/Users/anilsorathiya/Library/Caches/pypoetry/virtualenvs/validmind-1QuffXMV-py3.10/lib/python3.10/site-packages/sklearn/base.py:465: UserWarning: X does not have valid feature names, but RandomForestRegressor was fitted with feature names\n",
+      "  warnings.warn(\n",
+      "2024-10-01 14:12:48,142 - INFO(validmind.vm_models.dataset.utils): Done running predict()\n",
+      "2024-10-01 14:12:48,143 - INFO(validmind.vm_models.dataset.dataset): No probabilities computed or provided. Not adding probability column to the dataset.\n",
+      "2024-10-01 14:12:48,144 - INFO(validmind.vm_models.dataset.utils): Running predict_proba()... This may take a while\n",
+      "2024-10-01 14:12:48,144 - INFO(validmind.vm_models.dataset.utils): Not running predict_proba() for unsupported models.\n",
+      "2024-10-01 14:12:48,144 - INFO(validmind.vm_models.dataset.utils): Running predict()... This may take a while\n",
+      "/Users/anilsorathiya/Library/Caches/pypoetry/virtualenvs/validmind-1QuffXMV-py3.10/lib/python3.10/site-packages/sklearn/base.py:465: UserWarning: X does not have valid feature names, but GradientBoostingRegressor was fitted with feature names\n",
+      "  warnings.warn(\n",
+      "2024-10-01 14:12:48,150 - INFO(validmind.vm_models.dataset.utils): Done running predict()\n",
+      "2024-10-01 14:12:48,151 - INFO(validmind.vm_models.dataset.dataset): No probabilities computed or provided. Not adding probability column to the dataset.\n"
+     ]
+    }
+   ],
    "source": [
     "vm_train_ds.assign_predictions(\n",
     "    model=vm_model,\n",
@@ -402,11 +669,96 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "id": "NgzKVN_gSPc8"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2024-10-01 14:12:48,156 - ERROR(validmind.tests.load): Unable to load test validmind.model_validation.sklearn.RegressionModelsPerformanceComparison. No module named 'validmind.tests.model_validation.sklearn.RegressionModelsPerformanceComparison'\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7cf4d15ee285465eb6f56ce9fcb3723b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(Label(value='Running test suite...'), IntProgress(value=0, max=32)))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e40b14cb083d4666a54a077e8d32b526",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(HTML(value='<h2>Test Suite Results: <i style=\"color: #DE257E\">Regression V1</i></h2><hr>'), HTM…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<script defer type=\"module\">\n",
+       "import hljs from 'https://unpkg.com/@highlightjs/cdn-assets@11.9.0/es/highlight.min.js';\n",
+       "import python from 'https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/es/languages/python.min.js';\n",
+       "\n",
+       "hljs.registerLanguage('python', python);\n",
+       "hljs.highlightAll();\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<script>\n",
+       "window.MathJax = {\n",
+       "    tex2jax: {\n",
+       "        inlineMath: [['$', '$'], ['\\\\(', '\\\\)']],\n",
+       "        displayMath: [['$$', '$$'], ['\\[', '\\]']],\n",
+       "        processEscapes: true,\n",
+       "        skipTags: ['script', 'noscript', 'style', 'textarea', 'pre'],\n",
+       "        ignoreClass: \".*\",\n",
+       "        processClass: \"math\"\n",
+       "    }\n",
+       "};\n",
+       "setTimeout(function () {\n",
+       "    var script = document.createElement('script');\n",
+       "    script.type = 'text/javascript';\n",
+       "    script.src = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?config=TeX-AMS_HTML';\n",
+       "    document.head.appendChild(script);\n",
+       "}, 300);\n",
+       "</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "full_suite = vm.run_documentation_tests(\n",
     "    inputs={\n",
@@ -459,7 +811,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/notebooks/code_samples/regression/quickstart_regression_full_suite.ipynb
+++ b/notebooks/code_samples/regression/quickstart_regression_full_suite.ipynb
@@ -112,20 +112,7 @@
     "  api_key = \"...\",\n",
     "  api_secret = \"...\",\n",
     "  project = \"...\"\n",
-    ")\n",
-    "\n",
-    "\n",
-    "import logging\n",
-    "import sys\n",
-    "import site\n",
-    "\n",
-    "logger = logging.getLogger()\n",
-    "\n",
-    "# Print the path to the current Python interpreter\n",
-    "logger.info(\"Python executable path: \" + sys.executable)\n",
-    "\n",
-    "# Print the path to the site-packages directory\n",
-    "logger.info(\"Site-packages path: \" + str(site.getsitepackages()))\n"
+    ")\n"
    ]
   },
   {

--- a/notebooks/how_to/run_tests/2_run_comparison_tests.ipynb
+++ b/notebooks/how_to/run_tests/2_run_comparison_tests.ipynb
@@ -40,7 +40,8 @@
     "  - [Run the test with one model](#toc5_5_)      \n",
     "- [Run comparison tests](#toc6_)    \n",
     "  - [Run a comparison test with multiple models](#toc6_1_)    \n",
-    "  - [Run a classifier performance comparison test](#toc6_2_)      \n",
+    "  - [Run a comparison test with multiple parameters' value](#toc6_2_)    \n",
+    "  - [Run a classifier performance comparison test](#toc6_3_)      \n",
     "- [Add test results to documentation](#toc7_)    \n",
     "- [Next steps](#toc8_)    \n",
     "  - [Discover more learning resources](#toc8_1_)    \n",
@@ -356,7 +357,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,7 +406,7 @@
    "outputs": [],
    "source": [
     "result = vm.tests.run_test(\n",
-    "    test_id,\n",
+    "    \"validmind.model_validation.sklearn.ClassifierPerformance\",\n",
     "    inputs={\n",
     "        \"dataset\": vm_test_ds,\n",
     "        \"model\": vm_model_xgb,\n",
@@ -444,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -526,6 +527,34 @@
    "metadata": {},
    "source": [
     "<a id='toc6_2_'></a>\n",
+    "### Run a comparison test with multiple values of a parameter\n",
+    "\n",
+    "Now you can run the test with the `param_grid` object. Note that we're adding a small extra identifier to the test ID to differentiate the results in the documentation. This is optional, but it can be useful to differentiate the results when you have multiple tests with the same ID."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parameter_comparison_result = vm.tests.run_test(\n",
+    "    \"validmind.model_validation.sklearn.ClassifierPerformance:parameter_grid\",\n",
+    "    input_grid={\n",
+    "        \"dataset\": [vm_test_ds],\n",
+    "        \"model\": [vm_model_xgb,]\n",
+    "    },\n",
+    "    param_grid={\n",
+    "        \"average\": [\"macro\", \"micro\"]\n",
+    "    },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='toc6_3_'></a>\n",
     "\n",
     "### Run a comparison test with multiple datasets\n",
     "\n",

--- a/notebooks/how_to/run_tests/2_run_comparison_tests.ipynb
+++ b/notebooks/how_to/run_tests/2_run_comparison_tests.ipynb
@@ -40,7 +40,7 @@
     "  - [Run the test with one model](#toc5_5_)      \n",
     "- [Run comparison tests](#toc6_)    \n",
     "  - [Run a comparison test with multiple models](#toc6_1_)    \n",
-    "  - [Run a comparison test with multiple parameters' value](#toc6_2_)    \n",
+    "  - [Run a comparison test with multiple parameters' values](#toc6_2_)    \n",
     "  - [Run a classifier performance comparison test](#toc6_3_)      \n",
     "- [Add test results to documentation](#toc7_)    \n",
     "- [Next steps](#toc8_)    \n",
@@ -527,7 +527,7 @@
    "metadata": {},
    "source": [
     "<a id='toc6_2_'></a>\n",
-    "### Run a comparison test with multiple values of a parameter\n",
+    "### Run a comparison test with multiple parameters' values\n",
     "\n",
     "Now you can run the test with the `param_grid` object. Note that we're adding a small extra identifier to the test ID to differentiate the results in the documentation. This is optional, but it can be useful to differentiate the results when you have multiple tests with the same ID."
    ]

--- a/validmind/tests/data_validation/BoxPierce.py
+++ b/validmind/tests/data_validation/BoxPierce.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
 
 import pandas as pd
-
 from statsmodels.stats.diagnostic import acorr_ljungbox
 
 from validmind import tags, tasks

--- a/validmind/tests/data_validation/JarqueBera.py
+++ b/validmind/tests/data_validation/JarqueBera.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
 
 import pandas as pd
-
 from statsmodels.stats.stattools import jarque_bera
 
 from validmind import tags, tasks

--- a/validmind/tests/data_validation/LJungBox.py
+++ b/validmind/tests/data_validation/LJungBox.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
 
 import pandas as pd
-
 from statsmodels.stats.diagnostic import acorr_ljungbox
 
 from validmind import tags, tasks

--- a/validmind/tests/data_validation/RunsTest.py
+++ b/validmind/tests/data_validation/RunsTest.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
 
 import pandas as pd
-
 from statsmodels.sandbox.stats.runs import runstest_1samp
 
 from validmind import tags, tasks

--- a/validmind/tests/data_validation/ShapiroWilk.py
+++ b/validmind/tests/data_validation/ShapiroWilk.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
 
 import pandas as pd
-
 from scipy import stats
 
 from validmind import tags, tasks

--- a/validmind/tests/model_validation/sklearn/ClassifierPerformance.py
+++ b/validmind/tests/model_validation/sklearn/ClassifierPerformance.py
@@ -67,6 +67,7 @@ class ClassifierPerformance(Metric):
         "multiclass_classification",
         "model_performance",
     ]
+    default_params = {"average": "macro"}
 
     def summary(self, metric_value: dict):
         """
@@ -134,11 +135,13 @@ class ClassifierPerformance(Metric):
         if len(np.unique(y_true)) > 2:
             y_pred = self.inputs.dataset.y_pred(self.inputs.model)
             y_true = y_true.astype(y_pred.dtype)
-            roc_auc = multiclass_roc_auc_score(y_true, y_pred)
+            roc_auc = multiclass_roc_auc_score(
+                y_true, y_pred, average=self.params["average"]
+            )
         else:
             y_prob = self.inputs.dataset.y_prob(self.inputs.model)
             y_true = y_true.astype(y_prob.dtype).flatten()
-            roc_auc = roc_auc_score(y_true, y_prob)
+            roc_auc = roc_auc_score(y_true, y_prob, average=self.params["average"])
 
         report["roc_auc"] = roc_auc
 

--- a/validmind/tests/model_validation/statsmodels/DurbinWatsonTest.py
+++ b/validmind/tests/model_validation/statsmodels/DurbinWatsonTest.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
 
 import pandas as pd
-
 from statsmodels.stats.stattools import durbin_watson
 
 from validmind import tags, tasks

--- a/validmind/tests/run.py
+++ b/validmind/tests/run.py
@@ -408,7 +408,7 @@ def run_test(
     params (dict, optional): A dictionary of parameters to pass into the test. Params
         are used to customize the test behavior and are specific to each test. See the
         test details for more information on the available parameters. Defaults to None.
-    input_grid (Union[Dict[str, List[Any]], List[Dict[str, Any]]], optional): To run
+    param_grid (Union[Dict[str, List[Any]], List[Dict[str, Any]]], optional): To run
         a comparison test, provide either a dictionary of parameters where the keys are
         the parameter names and the values are lists of different parameters, or a list of
         dictionaries where each dictionary is a set of parameters to run the test with.

--- a/validmind/tests/run.py
+++ b/validmind/tests/run.py
@@ -199,7 +199,7 @@ def metric_comparison(
             ):
                 new_group[metric_k] = ", ".join([item.input_id for item in metric_v])
             else:
-                raise ValueError(f"Unsupported type for value: {v}")
+                raise ValueError(f"Unsupported type for value: {metric_v}")
         input_group_strings.append(new_group)
 
     # handle unit metrics (scalar values) by adding it to the summary
@@ -403,110 +403,42 @@ def run_test(
     __generate_description: bool = True,
     **kwargs,
 ) -> Union[MetricResultWrapper, ThresholdTestResultWrapper]:
-    """Run a test by test ID
+    """Run a test by test ID."""
 
-    Args:
-        test_id (TestID, optional): The test ID to run. Not required if `unit_metrics` is provided.
-        params (dict, optional): A dictionary of parameters to pass into the test. Params
-            are used to customize the test behavior and are specific to each test. See the
-            test details for more information on the available parameters. Defaults to None.
-        inputs (Dict[str, Any], optional): A dictionary of test inputs to pass into the
-            test. Inputs are either models or datasets that have been initialized using
-            vm.init_model() or vm.init_dataset(). Defaults to None.
-        input_grid (Union[Dict[str, List[Any]], List[Dict[str, Any]]], optional): To run
-            a comparison test, provide either a dictionary of inputs where the keys are
-            the input names and the values are lists of different inputs, or a list of
-            dictionaries where each dictionary is a set of inputs to run the test with.
-            This will run the test multiple times with different sets of inputs and then
-            combine the results into a single output. When passing a dictionary, the grid
-            will be created by taking the Cartesian product of the input lists. Its simply
-            a more convenient way of forming the input grid as opposed to passing a list of
-            all possible combinations. Defaults to None.
-        name (str, optional): The name of the test (used to create a composite metric
-            out of multiple unit metrics) - required when running multiple unit metrics
-        unit_metrics (list, optional): A list of unit metric IDs to run as a composite
-            metric - required when running multiple unit metrics
-        output_template (str, optional): A jinja2 html template to customize the output
-            of the test. Defaults to None.
-        show (bool, optional): Whether to display the results. Defaults to True.
-        **kwargs: Keyword inputs to pass into the test (same as `inputs` but as keyword
-            args instead of a dictionary):
-            - dataset: A validmind Dataset object or a Pandas DataFrame
-            - model: A model to use for the test
-            - models: A list of models to use for the test
-            - dataset: A validmind Dataset object or a Pandas DataFrame
-    """
-    if not test_id and not name and not unit_metrics:
-        raise ValueError(
-            "`test_id` or `name` and `unit_metrics` must be provided to run a test"
-        )
+    # Validate input arguments with helper functions
+    validate_test_inputs(test_id, name, unit_metrics)
+    validate_grid_inputs(input_grid, kwargs, inputs, param_grid, params)
 
-    if (unit_metrics and not name) or (name and not unit_metrics):
-        raise ValueError("`name` and `unit_metrics` must be provided together")
-
-    if (input_grid and kwargs) or (input_grid and inputs):
-        raise ValueError(
-            "When providing an `input_grid`, you cannot also provide `inputs` or `kwargs`"
-        )
-
-    if (param_grid and kwargs) or (param_grid and params):
-        raise ValueError(
-            "When providing an `param_grid`, you cannot also provide `params` or `kwargs`"
-        )
-
+    # Handle composite metric creation
     if unit_metrics:
-        metric_id_name = "".join(word[0].upper() + word[1:] for word in name.split())
-        test_id = f"validmind.composite_metric.{metric_id_name}" or test_id
+        test_id = generate_composite_test_id(name, test_id)
 
-    if input_grid and param_grid:
-        return run_comparison_test(
+    # Run comparison tests if applicable
+    if input_grid or param_grid:
+        return run_comparison_test_with_grids(
             test_id,
+            inputs,
             input_grid,
-            name=name,
-            unit_metrics=unit_metrics,
-            param_grid=param_grid,
-            output_template=output_template,
-            show=show,
-            generate_description=__generate_description,
-        )
-    if input_grid:
-        return run_comparison_test(
-            test_id,
-            input_grid,
-            name=name,
-            unit_metrics=unit_metrics,
-            params=params,
-            output_template=output_template,
-            show=show,
-            generate_description=__generate_description,
-        )
-    if param_grid:
-        return run_comparison_test(
-            test_id,
-            inputs=inputs,
-            name=name,
-            unit_metrics=unit_metrics,
-            param_grid=param_grid,
-            output_template=output_template,
-            show=show,
-            generate_description=__generate_description,
+            param_grid,
+            name,
+            unit_metrics,
+            params,
+            output_template,
+            show,
+            __generate_description,
         )
 
+    # Run unit metric tests
     if test_id.startswith("validmind.unit_metrics"):
         # TODO: as we move towards a more unified approach to metrics
         # we will want to make everything functional and remove the
         # separation between unit metrics and "normal" metrics
         return run_metric(test_id, inputs=inputs, params=params, show=show)
 
-    if unit_metrics:
-        error, TestClass = load_composite_metric(
-            unit_metrics=unit_metrics, metric_name=metric_id_name
-        )
-        if error:
-            raise LoadTestError(error)
-    else:
-        TestClass = load_test(test_id, reload=True)
+    # Load the appropriate test class
+    TestClass = load_test_class(test_id, unit_metrics, name)
 
+    # Create and run the test
     test = TestClass(
         test_id=test_id,
         context=TestContext(),
@@ -522,3 +454,90 @@ def run_test(
         test.result.show()
 
     return test.result
+
+
+def validate_test_inputs(test_id, name, unit_metrics):
+    """Validate the main test inputs for `test_id`, `name`, and `unit_metrics`."""
+    if not test_id and not (name and unit_metrics):
+        raise ValueError(
+            "`test_id` or both `name` and `unit_metrics` must be provided to run a test"
+        )
+
+    if bool(unit_metrics) != bool(name):
+        raise ValueError("`name` and `unit_metrics` must be provided together")
+
+
+def validate_grid_inputs(input_grid, kwargs, inputs, param_grid, params):
+    """Validate the grid inputs to avoid conflicting parameters."""
+    if input_grid and (kwargs or inputs):
+        raise ValueError("Cannot provide `input_grid` along with `inputs` or `kwargs`")
+
+    if param_grid and (kwargs or params):
+        raise ValueError("Cannot provide `param_grid` along with `params` or `kwargs`")
+
+
+def generate_composite_test_id(name, test_id):
+    """Generate a composite test ID if unit metrics are provided."""
+    metric_id_name = "".join(word.capitalize() for word in name.split())
+    return f"validmind.composite_metric.{metric_id_name}" or test_id
+
+
+def run_comparison_test_with_grids(
+    test_id,
+    inputs,
+    input_grid,
+    param_grid,
+    name,
+    unit_metrics,
+    params,
+    output_template,
+    show,
+    generate_description,
+):
+    """Run a comparison test based on the presence of input and param grids."""
+    if input_grid and param_grid:
+        return run_comparison_test(
+            test_id,
+            input_grid,
+            name=name,
+            unit_metrics=unit_metrics,
+            param_grid=param_grid,
+            output_template=output_template,
+            show=show,
+            generate_description=generate_description,
+        )
+    if input_grid:
+        return run_comparison_test(
+            test_id,
+            input_grid,
+            name=name,
+            unit_metrics=unit_metrics,
+            params=params,
+            output_template=output_template,
+            show=show,
+            generate_description=generate_description,
+        )
+    if param_grid:
+        return run_comparison_test(
+            test_id,
+            inputs=inputs,
+            name=name,
+            unit_metrics=unit_metrics,
+            param_grid=param_grid,
+            output_template=output_template,
+            show=show,
+            generate_description=generate_description,
+        )
+
+
+def load_test_class(test_id, unit_metrics, name):
+    """Load the appropriate test class based on `test_id` and unit metrics."""
+    if unit_metrics:
+        metric_id_name = "".join(word.capitalize() for word in name.split())
+        error, TestClass = load_composite_metric(
+            unit_metrics=unit_metrics, metric_name=metric_id_name
+        )
+        if error:
+            raise LoadTestError(error)
+        return TestClass
+    return load_test(test_id, reload=True)

--- a/validmind/tests/run.py
+++ b/validmind/tests/run.py
@@ -403,7 +403,46 @@ def run_test(
     __generate_description: bool = True,
     **kwargs,
 ) -> Union[MetricResultWrapper, ThresholdTestResultWrapper]:
-    """Run a test by test ID."""
+    """Run a test by test ID.
+    test_id (TestID, optional): The test ID to run. Not required if `unit_metrics` is provided.
+    params (dict, optional): A dictionary of parameters to pass into the test. Params
+        are used to customize the test behavior and are specific to each test. See the
+        test details for more information on the available parameters. Defaults to None.
+    input_grid (Union[Dict[str, List[Any]], List[Dict[str, Any]]], optional): To run
+        a comparison test, provide either a dictionary of parameters where the keys are
+        the parameter names and the values are lists of different parameters, or a list of
+        dictionaries where each dictionary is a set of parameters to run the test with.
+        This will run the test multiple times with different sets of parameters and then
+        combine the results into a single output. When passing a dictionary, the grid
+        will be created by taking the Cartesian product of the parameter lists. Its simply
+        a more convenient way of forming the param grid as opposed to passing a list of
+        all possible combinations. Defaults to None.
+    inputs (Dict[str, Any], optional): A dictionary of test inputs to pass into the
+        test. Inputs are either models or datasets that have been initialized using
+        vm.init_model() or vm.init_dataset(). Defaults to None.
+    input_grid (Union[Dict[str, List[Any]], List[Dict[str, Any]]], optional): To run
+        a comparison test, provide either a dictionary of inputs where the keys are
+        the input names and the values are lists of different inputs, or a list of
+        dictionaries where each dictionary is a set of inputs to run the test with.
+        This will run the test multiple times with different sets of inputs and then
+        combine the results into a single output. When passing a dictionary, the grid
+        will be created by taking the Cartesian product of the input lists. Its simply
+        a more convenient way of forming the input grid as opposed to passing a list of
+        all possible combinations. Defaults to None.
+    name (str, optional): The name of the test (used to create a composite metric
+        out of multiple unit metrics) - required when running multiple unit metrics
+    unit_metrics (list, optional): A list of unit metric IDs to run as a composite
+        metric - required when running multiple unit metrics
+    output_template (str, optional): A jinja2 html template to customize the output
+        of the test. Defaults to None.
+    show (bool, optional): Whether to display the results. Defaults to True.
+    **kwargs: Keyword inputs to pass into the test (same as `inputs` but as keyword
+        args instead of a dictionary):
+        - dataset: A validmind Dataset object or a Pandas DataFrame
+        - model: A model to use for the test
+        - models: A list of models to use for the test
+        - dataset: A validmind Dataset object or a Pandas DataFrame
+    """
 
     # Validate input arguments with helper functions
     validate_test_inputs(test_id, name, unit_metrics)


### PR DESCRIPTION
## Internal Notes for Reviewers

We support for comparison tests using the `input_grid` parameter in `run_test` functionality. However,  the similar support is required for params. This is useful for any sort of case where you might want to run the same test against multiple combinations of test parameters and create a single documentation block that compares the individual results.

The updated `run_test()` function now allows you to pass an `param_grid` that will run a test for all combinations of parameters.

Example - for this param grid:

```
param_grid = {
    "param1": [1],
    "param2": [0.1, 0.2],
}
```

A test will run once for each of the following param groups:

```
{"param1": 1, "param2": 0.1}
{"param1": 1, "param2": 0.2}
```

## External Release Notes

We support for comparison tests using the `input_grid` parameter in `run_test` functionality. However,  the similar support is required for params. This is useful for any sort of case where you might want to run the same test against multiple combinations of test parameters and create a single documentation block that compares the individual results.

The updated `run_test()` function now allows you to pass an `param_grid` that will run a test for all combinations of parameters.

Example - for this param grid:

```
param_grid = {
    "param1": [1],
    "param2": [0.1, 0.2],
}
```

A test will run once for each of the following param groups:

```
{"param1": 1, "param2": 0.1}
{"param1": 1, "param2": 0.2}
```
