### PR TITLE
Require aequitas at runtime

### DIFF
--- a/validmind/tests/data_validation/ProtectedClassesDisparity.py
+++ b/validmind/tests/data_validation/ProtectedClassesDisparity.py
@@ -5,11 +5,7 @@
 import io
 import sys
 
-import aequitas.plot as ap
 import pandas as pd
-from aequitas.bias import Bias
-from aequitas.group import Group
-from aequitas.plotting import Plot
 
 from validmind import tags, tasks
 from validmind.logging import get_logger
@@ -63,6 +59,15 @@ def ProtectedClassesDisparity(
     - Does not account for intersectionality between different protected attributes.
     - The interpretation of results may require domain expertise to understand the implications of observed disparities.
     """
+    try:
+        import aequitas.plot as ap
+        from aequitas.bias import Bias
+        from aequitas.group import Group
+        from aequitas.plotting import Plot
+    except ImportError:
+        raise RuntimeError(
+            "Required dependencies (aequitas) are not installed. Please install them with `pip install aequitas` to run this test."
+        )
 
     if protected_classes is None:
         logger.warning(


### PR DESCRIPTION
## Internal Notes for Reviewers

Not a necessary fix but this is an annoying condition where `aequitas` is required even to run `list_tests()`. @johnwalz97 the current issue with this library is that the `lightgbm` doesn't install (compile) cleanly on Mac and there are multiple hacks required in order to make it work. This is also why `aequitas` is not on `pyproject.toml` since it won't compile cleanly.

While we figure out a good solution to this I propose we only load the library at runtime so it will still work on JupyterHub et al.


## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->