### PR TITLE
fix: run integration tests on large runners

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -17,7 +17,8 @@ jobs:
   integration:
     # Don't rerun the integration tests after docs were generated
     if: "!contains(github.event.head_commit.message, 'Generate docs')"
-    runs-on: ubuntu-latest
+    runs-on:
+      group: ubuntu-vm-large
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Internal Notes for Reviewers
This is something I'd been going back and forth on, but now we've got a reason to use it. With all the large dependencies in the developer framework, we are eclipsing the relatively small amount of storage space on GitHub's standard runners. We already have a pool of larger runners being used to build our docker images faster, but they also have more disk space. If we notice jobs being queued, we can always add more large runners to the pool

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `chore`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes