### PR TITLE
[SC-15812] Pin qdrant-client version in RAG notebooks

### DIFF
--- a/notebooks/code_sharing/llm/rag_rfp_answer_generation.ipynb
+++ b/notebooks/code_sharing/llm/rag_rfp_answer_generation.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q qdrant-client"
+    "%pip install -q \"qdrant-client<1.10\""
    ]
   },
   {

--- a/notebooks/use_cases/nlp_and_llm/rag_benchmark_demo.ipynb
+++ b/notebooks/use_cases/nlp_and_llm/rag_benchmark_demo.ipynb
@@ -137,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q qdrant-client langchain langchain-openai sentencepiece"
+    "%pip install -q \"qdrant-client<1.10\" langchain langchain-openai sentencepiece"
    ]
   },
   {

--- a/notebooks/use_cases/nlp_and_llm/rag_documentation_demo.ipynb
+++ b/notebooks/use_cases/nlp_and_llm/rag_documentation_demo.ipynb
@@ -136,7 +136,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q qdrant-client langchain langchain-openai sentencepiece"
+    "%pip install -q \"qdrant-client<1.10\" langchain langchain-openai sentencepiece"
    ]
   },
   {


### PR DESCRIPTION
# Pull Request Description

## What and why?
Pinned `qdrant-client` to `<1.10` in the RAG notebooks to fix the LangChain/Qdrant version mismatch. Before this, newer `qdrant-client` releases caused runtime errors in collection setup and retrieval; after this change, the existing notebook code runs with a compatible client version.

## How to test
Run the affected RAG notebooks and verify the install step succeeds with `qdrant-client<1.10` and the existing Qdrant/LangChain cells run without the previous collection/retrieval errors.

## What needs special review?
<!-- Optional: Call out specific areas needing detailed review -->

## Dependencies, breaking changes, and deployment notes
<!-- A list of links to pull requests that are depend on or are dependencies of this PR -->
<!-- Any special deployment considerations? -->
<!-- List any breaking changes -->

## Release notes
<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `breaking-change`
- `deprecation`
- `documentation`
- `environment-variables`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [ ] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

