### PR TITLE
fix: include bool dtype in categorical columns for TabularDescriptionTables (ZD #609)

### DIFF
--- a/tests/unit_tests/data_validation/test_TabularDescriptionTables.py
+++ b/tests/unit_tests/data_validation/test_TabularDescriptionTables.py
@@ -82,3 +82,23 @@ class TestTabularDescriptionTables(unittest.TestCase):
         datetime_table = next(df for df in result if "Datetime Variable" in df.columns)
         self.assertEqual(len(datetime_table), 2)  # Should have 2 datetime columns
         self.assertTrue("Earliest Date" in datetime_table.columns)
+
+    def test_bool_columns_included_in_categorical(self):
+        df = pd.DataFrame(
+            {
+                "flag": pd.array([True, False, True, False, True], dtype=bool),
+                "active": pd.array([False, False, True, True, False], dtype=bool),
+                "num": [1, 2, 3, 4, 5],
+            }
+        )
+        vm_dataset = vm.init_dataset(input_id="bool_dataset", dataset=df, __log=False)
+        result = TabularDescriptionTables(vm_dataset)
+
+        categorical_table = next(
+            (t for t in result if "Categorical Variable" in t.columns), None
+        )
+        self.assertIsNotNone(categorical_table, "Categorical table should be present")
+        categorical_vars = categorical_table["Categorical Variable"].tolist()
+        self.assertIn("flag", categorical_vars)
+        self.assertIn("active", categorical_vars)
+        self.assertEqual(len(categorical_vars), 2)

--- a/validmind/tests/data_validation/TabularDescriptionTables.py
+++ b/validmind/tests/data_validation/TabularDescriptionTables.py
@@ -177,7 +177,7 @@ def get_summary_statistics_datetime(dataset, datetime_fields):
 
 def get_categorical_columns(dataset):
     categorical_columns = dataset.df.select_dtypes(
-        include=["object", "category"]
+        include=["object", "category", "bool"]
     ).columns.tolist()
     return categorical_columns
 


### PR DESCRIPTION
# Pull Request Description

## What and why?
`TabularDescriptionTables.py` classifies columns by pandas dtype via `select_dtypes()`. The three helpers cover `int`/`float`/`uint8` (numerical), `object`/`category` (categorical), and `datetime`, but `bool` is absent absent. A column with `dtype=bool` falls through every check and is never included.

## How to test
Supply a bool dataframe to the dataset.

## What needs special review?
None

## Dependencies, breaking changes, and deployment notes
None

## Release notes
- Fix: include `bool` data fields in categorical table results

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [ ] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [ ] PR linked to Shortcut
- [x] Unit tests added (Backend)
- [ ] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

