### PR TITLE
chore: Drop python 3.9

### DIFF
--- a/.github/workflows/dependency-testing.yaml
+++ b/.github/workflows/dependency-testing.yaml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         deps-type: ['max', 'default']
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "validmind"
 version = "2.13.0"
 description = "ValidMind Library"
 readme = "README.pypi.md"
-requires-python = ">=3.9,<3.15"
+requires-python = ">=3.10,<3.15"
 license = { file = "LICENSE" }
 authors = [
   { name = "Andres Rodriguez", email = "andres@validmind.ai" },


### PR DESCRIPTION
# Pull Request Description

## What and why?
Python 3.9 is EOL in October last year https://devguide.python.org/versions/ and the `Test Python 3.9 with max dependencies` github action job takes 22 minutes. So lets drop it.

## How to test
None

## What needs special review?
None

## Dependencies, breaking changes, and deployment notes
None

## Release notes
- Drop python 3.9 support

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [ ] How to test
- [ ] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [ ] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [ ] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

