### PR TITLE
[SC-16186] Fix notebook e2e runner to pass document to vm.init

### DIFF
--- a/scripts/run_e2e_notebooks.py
+++ b/scripts/run_e2e_notebooks.py
@@ -96,7 +96,8 @@ vm.init(
   api_host = "{api_host}",
   api_key = "{api_key}",
   api_secret = "{api_secret}",
-  model = "{model}"
+  model = "{model}",
+  document = "documentation"
 )
 
 


### PR DESCRIPTION
# Pull Request Description

## What and why?
The notebook integration runner was rewriting `vm.init(...)` calls without including the `document` argument, even though the documentation notebooks already pass `document="documentation"`. This made CI execute a different initialization path than the notebooks themselves and could omit the document header required by the API.

## How to test
<!-- Describe how the change has been tested, and how a reviewer can test the change locally -->

## What needs special review?
<!-- Optional: Call out specific areas needing detailed review -->

## Dependencies, breaking changes, and deployment notes
<!-- A list of links to pull requests that are depend on or are dependencies of this PR -->
<!-- Any special deployment considerations? -->
<!-- List any breaking changes -->

## Release notes
<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `breaking-change`
- `deprecation`
- `documentation`
- `environment-variables`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [ ] How to test
- [ ] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [ ] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

