### PR TITLE
docs: SR 26-2 references in notebook and configs

### DIFF
--- a/notebooks/use_cases/agents/document_agentic_ai.ipynb
+++ b/notebooks/use_cases/agents/document_agentic_ai.ipynb
@@ -2064,7 +2064,7 @@
     "\n",
     "### Customize the banking agent for your use case\n",
     "\n",
-    "You've now built an agentic AI system designed for banking use cases that supports compliance with supervisory guidance such as SR 11-7 and SS1/23, covering credit and fraud risk assessment for both retail and commercial banking. Extend this example agent to real-world banking scenarios and production deployment by:\n",
+    "You've now built an agentic AI system designed for banking use cases that supports compliance with supervisory guidance such as SR 26-2 and SS1/23. While SR 26-2 explicitly excludes generative and agentic AI from its scope, underlying principles — materiality, ongoing monitoring, and effective challenge — still apply to governance of these systems. The example covers credit and fraud risk assessment for both retail and commercial banking. Extend this example agent to real-world banking scenarios and production deployment by:\n",
     "\n",
     "- Adapting the banking tools to your organization's specific requirements\n",
     "- Adding more banking scenarios and edge cases to your test set\n",

--- a/notebooks/use_cases/capital_markets/capital_markets_template.yaml
+++ b/notebooks/use_cases/capital_markets/capital_markets_template.yaml
@@ -40,7 +40,7 @@
           with business goals.
         - Include specific use cases, outputs, and highlight regulatory
           expectations to demonstrate compliance.
-        - Specify compliance requirements, such as IFRS, Basel III or SR11-7, as
+        - Specify compliance requirements, such as IFRS, Basel III or SR 26-2, as
           applicable.
     - id: products_and_risks
       title: Products and Risks

--- a/validmind/datasets/classification/config.json
+++ b/validmind/datasets/classification/config.json
@@ -14,7 +14,7 @@
   },
   "regulatory_requirements": {
     "section_id": "regulatory_requirements",
-    "prompt": "Write a comprehensive paragraphs describing the regulatory requirements for this model, assuming SR 11-7 is the primary regulatory framework."
+    "prompt": "Write a comprehensive paragraphs describing the regulatory requirements for this model, assuming SR 26-2 is the primary regulatory framework for U.S. banking organizations (superseding SR 11-7)."
   },
   "model_limitations": {
     "section_id": "model_limitations",


### PR DESCRIPTION
## What and why?
Updates SR 11-7 / SR11-7 references to **SR 26-2** for consistency with current U.S. interagency MRM guidance: the agentic AI use-case notebook closing text (including GenAI/agentic scope nuance), the capital markets documentation template compliance examples, and the classification dataset `regulatory_requirements` prompt in `config.json`.

## How to test
- Open `notebooks/use_cases/agents/document_agentic_ai.ipynb` and confirm the final summary markdown cell references SR 26-2 and the scope nuance.
- Confirm YAML and JSON edits are valid (pre-commit already ran `Check Yaml` on commit).

## What needs special review?
- Wording of the `config.json` prompt for regulatory section generation.

## Dependencies, breaking changes, and deployment notes
- Companion documentation site PR: https://github.com/validmind/documentation/pull/1331 (sc-16033). No hard dependency for merge order, but content aligns across repos.

## Release notes
Notebook and template text now reference SR 26-2 instead of SR 11-7 where U.S. MRM guidance is cited.

## Checklist
- [x] What and why
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied
- [ ] PR linked to Shortcut
- [x] Documentation updated (if required)