### PR TITLE
[SC 16234] Two small fixes to built-in ValidMind tests

### DIFF
--- a/tests/unit_tests/data_validation/test_IQROutliersBarPlot.py
+++ b/tests/unit_tests/data_validation/test_IQROutliersBarPlot.py
@@ -81,3 +81,20 @@ class TestIQROutliersBarPlot(unittest.TestCase):
         # Check that binary column is not included in figures
         figure_titles = [fig.layout.title.text for fig in results[:-1]]
         self.assertNotIn("binary", figure_titles)
+
+    def test_boolean_dtype_excluded_from_raw_data(self):
+        n_samples = 100
+        df = pd.DataFrame(
+            {
+                "numeric": np.random.randn(n_samples),
+                "flag": np.random.choice([True, False], n_samples),
+            }
+        )
+        vm_dataset = vm.init_dataset(
+            input_id="test_boolean_dataset", dataset=df, __log=False
+        )
+
+        results = IQROutliersBarPlot(vm_dataset)
+        raw_data = results[-1]
+
+        self.assertNotIn("flag", raw_data.outlier_counts_by_feature.index)

--- a/tests/unit_tests/model_validation/sklearn/test_WeakspotsDiagnosis.py
+++ b/tests/unit_tests/model_validation/sklearn/test_WeakspotsDiagnosis.py
@@ -1,0 +1,31 @@
+import unittest
+
+from validmind.tests.model_validation.sklearn.WeakspotsDiagnosis import (
+    _prepare_metrics_and_thresholds,
+)
+
+
+class TestWeakspotsDiagnosisThresholds(unittest.TestCase):
+    def test_partial_thresholds_use_defaults_for_plotting(self):
+        _, plot_thresholds, pass_thresholds = _prepare_metrics_and_thresholds(
+            metrics=None,
+            thresholds={"accuracy": 0.65},
+        )
+
+        self.assertEqual(pass_thresholds, {"Accuracy": 0.65})
+        self.assertEqual(plot_thresholds["Accuracy"], 0.65)
+        self.assertEqual(plot_thresholds["Precision"], 0.5)
+        self.assertEqual(plot_thresholds["Recall"], 0.5)
+        self.assertEqual(plot_thresholds["F1"], 0.7)
+
+    def test_partial_thresholds_subset_for_pass_fail(self):
+        _, _, pass_thresholds = _prepare_metrics_and_thresholds(
+            metrics=None,
+            thresholds={"accuracy": 0.75, "f1": 0.55},
+        )
+
+        self.assertEqual(set(pass_thresholds.keys()), {"Accuracy", "F1"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validmind/tests/data_validation/IQROutliersBarPlot.py
+++ b/validmind/tests/data_validation/IQROutliersBarPlot.py
@@ -76,12 +76,14 @@ def IQROutliersBarPlot(
     """
     df = dataset.df
 
+    # Exclude binary/boolean features (IQR is not meaningful and quantile fails on bool)
+    eligible_columns = [
+        col for col in dataset.feature_columns_numeric if len(df[col].unique()) > 2
+    ]
+
     figures = []
 
-    for col in dataset.feature_columns_numeric:
-        # Skip binary features
-        if len(df[col].unique()) <= 2:
-            continue
+    for col in eligible_columns:
 
         outliers = compute_outliers(df[col], threshold)
         if outliers.empty:
@@ -121,8 +123,10 @@ def IQROutliersBarPlot(
         )
         figures.append(fig)
 
-    outliers_by_feature = df[dataset.feature_columns_numeric].apply(
-        lambda col: compute_outliers(col, threshold)
+    outliers_by_feature = (
+        df[eligible_columns].apply(lambda col: compute_outliers(col, threshold))
+        if eligible_columns
+        else df.iloc[:, 0:0]
     )
 
     return (

--- a/validmind/tests/model_validation/sklearn/WeakspotsDiagnosis.py
+++ b/validmind/tests/model_validation/sklearn/WeakspotsDiagnosis.py
@@ -27,6 +27,36 @@ DEFAULT_THRESHOLDS = {
 }
 
 
+def _normalize_dict_keys(d: Dict) -> Dict:
+    """Normalize metric/threshold keys to title case (e.g. 'f1' -> 'F1')."""
+    return {k.title(): v for k, v in d.items()}
+
+
+def _prepare_metrics_and_thresholds(
+    metrics: Optional[Dict[str, Callable]],
+    thresholds: Optional[Dict[str, float]],
+) -> Tuple[Dict[str, Callable], Dict[str, float], Dict[str, float]]:
+    """
+    Prepare metrics and threshold dicts for plotting and pass/fail checks.
+
+    Custom thresholds may specify only a subset of metrics (e.g. accuracy only).
+    Plotting uses default thresholds for any metric without an explicit value so
+    charts always show a reference line; pass/fail uses only the user-provided
+    thresholds when a custom dict is supplied.
+    """
+    normalized_metrics = _normalize_dict_keys(metrics or DEFAULT_METRICS)
+    default_thresholds = _normalize_dict_keys(DEFAULT_THRESHOLDS)
+
+    if thresholds is not None:
+        pass_thresholds = _normalize_dict_keys(thresholds)
+        plot_thresholds = {**default_thresholds, **pass_thresholds}
+    else:
+        pass_thresholds = default_thresholds
+        plot_thresholds = default_thresholds
+
+    return normalized_metrics, plot_thresholds, pass_thresholds
+
+
 def _compute_metrics(
     results: dict,
     metrics: Dict[str, Callable],
@@ -230,11 +260,9 @@ def WeakspotsDiagnosis(
             "Column(s) provided in features_columns do not exist in the dataset"
         )
 
-    metrics = metrics or DEFAULT_METRICS
-    metrics = {k.title(): v for k, v in metrics.items()}
-
-    thresholds = thresholds or DEFAULT_THRESHOLDS
-    thresholds = {k.title(): v for k, v in thresholds.items()}
+    metrics, plot_thresholds, pass_thresholds = _prepare_metrics_and_thresholds(
+        metrics, thresholds
+    )
 
     results_headers = ["Slice", "Number of Records", "Feature"]
     results_headers.extend(metrics.keys())
@@ -290,14 +318,18 @@ def WeakspotsDiagnosis(
                 results_2=r2,
                 feature_column=feature,
                 metric=metric,
-                threshold=thresholds[metric],
+                threshold=plot_thresholds[metric],
             )
 
             figures.append(fig)
 
         # For simplicity, test has failed if any of the metrics is below the threshold. We will
         # rely on visual assessment for this test for now.
-        if not df[df[list(thresholds.keys())].lt(thresholds).any(axis=1)].empty:
+        pass_columns = [c for c in pass_thresholds if c in metrics]
+        if (
+            pass_columns
+            and not df[df[pass_columns].lt(pass_thresholds).any(axis=1)].empty
+        ):
             passed = False
         results_1 = pd.concat([results_1, pd.DataFrame(r1)])
         results_2 = pd.concat([results_2, pd.DataFrame(r2)])


### PR DESCRIPTION
# Pull Request Description

## What and why?

**IQROutliersBarPlot** — Boolean and binary columns (≤2 unique values) are now excluded from plots and from the raw outlier summary table. Before, they could appear in raw data or cause quantile errors on boolean dtypes. After, only meaningful numeric features are analyzed.

```python
import numpy as np
import pandas as pd
import validmind as vm
df = pd.DataFrame({
    "numeric": np.random.randn(100),
    "flag": np.random.choice([True, False], 100),
})
dataset = vm.init_dataset(input_id="ds", dataset=df, __log=False)
result = vm.tests.run_test(
    "validmind.data_validation.IQROutliersBarPlot",
    inputs={"dataset": dataset},
)
result.show()
```

**WeakspotsDiagnosis** — Custom `thresholds` can now specify only some metrics (e.g. `{"accuracy": 0.65}`). Before, missing keys could break plots or pass/fail logic. After, plots use defaults for metrics without a custom threshold (reference lines still show), and pass/fail only checks the thresholds you provide.
```python
result = vm.tests.run_test(
    "validmind.model_validation.sklearn.WeakspotsDiagnosis",
    inputs={"datasets": [train_ds, test_ds], "model": model},
    params={"thresholds": {"accuracy": 0.65}},  # only accuracy used for pass/fail
)
```
## How to test

```bash
pytest tests/unit_tests/data_validation/test_IQROutliersBarPlot.py -v
pytest tests/unit_tests/model_validation/sklearn/test_WeakspotsDiagnosis.py -v
```

Manual checks (optional):

- Run `IQROutliersBarPlot` on a dataset with boolean columns; confirm they are not in the bar plots or raw outlier table.
- Run `WeakspotsDiagnosis` with `thresholds={"accuracy": 0.65}`; confirm plots show reference lines for all metrics and pass/fail only uses accuracy.

## What needs special review?

- `WeakspotsDiagnosis`: split between `plot_thresholds` (defaults + overrides) and `pass_thresholds` (user-only when custom thresholds are passed).
- `IQROutliersBarPlot`: `eligible_columns` filter applied consistently to plots and raw data.

## Dependencies, breaking changes, and deployment notes

## Release notes

- **IQROutliersBarPlot:** Boolean and binary features are excluded from outlier analysis and summary output.
- **WeakspotsDiagnosis:** You can pass partial custom thresholds; plots still show default reference lines for other metrics, and pass/fail only evaluates the thresholds you set.

## Checklist

- [x] What and why
- [ ] Screenshots or videos (Frontend) — N/A
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut (SC-16234)
- [x] Unit tests added (Backend)
- [ ] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

