### PR TITLE
[SC 16935] Fix IQROutliersBarPlot failure on boolean numeric

### DIFF
--- a/tests/unit_tests/data_validation/test_IQROutliersBarPlot.py
+++ b/tests/unit_tests/data_validation/test_IQROutliersBarPlot.py
@@ -97,4 +97,4 @@ class TestIQROutliersBarPlot(unittest.TestCase):
         results = IQROutliersBarPlot(vm_dataset)
         raw_data = results[-1]
 
-        self.assertNotIn("flag", raw_data.outlier_counts_by_feature.index)
+        self.assertNotIn("flag", raw_data.outlier_counts_by_feature.columns)

--- a/tests/unit_tests/data_validation/test_IQROutliersTable.py
+++ b/tests/unit_tests/data_validation/test_IQROutliersTable.py
@@ -83,3 +83,25 @@ class TestIQROutliersTable(unittest.TestCase):
         # Verify binary column is not in results
         for summary in outliers_summary:
             self.assertNotIn("binary", summary["Variable"])
+
+    def test_boolean_dtype_excluded_from_raw_data(self):
+        n_samples = 100
+        normal_data = np.array([1.0] * 25 + [2.0] * 50 + [3.0] * 25)
+        data_with_outliers = normal_data.copy()
+        data_with_outliers[0:4] = [-15, -10, 10, 15]
+        df = pd.DataFrame(
+            {
+                "with_outliers": data_with_outliers,
+                "flag": np.random.choice([True, False], n_samples),
+            }
+        )
+        vm_dataset = vm.init_dataset(
+            input_id="test_boolean_dataset", dataset=df, __log=False
+        )
+
+        result, raw_data = IQROutliersTable(vm_dataset)
+        outliers_summary = result["Summary of Outliers Detected by IQR Method"]
+        summary_variables = [summary["Variable"] for summary in outliers_summary]
+
+        self.assertNotIn("flag", summary_variables)
+        self.assertNotIn("flag", raw_data.all_outliers)

--- a/validmind/tests/data_validation/IQROutliersBarPlot.py
+++ b/validmind/tests/data_validation/IQROutliersBarPlot.py
@@ -5,6 +5,7 @@
 
 from typing import Tuple
 
+import pandas as pd
 import plotly.graph_objects as go
 
 from validmind import RawData, tags, tasks
@@ -76,9 +77,12 @@ def IQROutliersBarPlot(
     """
     df = dataset.df
 
-    # Exclude binary/boolean features (IQR is not meaningful and quantile fails on bool)
+    # Exclude boolean and binary features. The IQR is not meaningful for them and
+    # `quantile` raises "numpy boolean subtract" on boolean dtype columns.
     eligible_columns = [
-        col for col in dataset.feature_columns_numeric if len(df[col].unique()) > 2
+        col
+        for col in dataset.feature_columns_numeric
+        if not pd.api.types.is_bool_dtype(df[col]) and df[col].nunique() > 2
     ]
 
     figures = []

--- a/validmind/tests/data_validation/IQROutliersTable.py
+++ b/validmind/tests/data_validation/IQROutliersTable.py
@@ -5,6 +5,8 @@
 
 from typing import Any, Dict, Tuple
 
+import pandas as pd
+
 from validmind import RawData, tags, tasks
 from validmind.vm_models import VMDataset
 
@@ -72,8 +74,9 @@ def IQROutliersTable(
     all_outliers = {}
 
     for col in dataset.feature_columns_numeric:
-        # Skip binary features
-        if len(df[col].unique()) <= 2:
+        # Skip boolean and binary features. The IQR is not meaningful for them and
+        # `quantile` raises "numpy boolean subtract" on boolean dtype columns.
+        if pd.api.types.is_bool_dtype(df[col]) or df[col].nunique() <= 2:
             continue
 
         outliers = compute_outliers(df[col], threshold)


### PR DESCRIPTION
# Pull Request Description

## What and why?

`IQROutliersBarPlot` failed with `TypeError: numpy boolean subtract` when a dataset included boolean columns in `feature_columns_numeric` (pandas treats `bool` as numeric).

**Before:** Boolean/binary columns could still be processed when building `outlier_counts_by_feature`, causing `quantile()` to fail on boolean data.

**After:** Boolean and binary features are excluded from IQR outlier calculations using `is_bool_dtype()` and `nunique() > 2`, for both plots and raw data output.

## How to test

```bash
pytest tests/unit_tests/data_validation/test_IQROutliersBarPlot.py -v
```

Or manually:

```python
import numpy as np
import pandas as pd
import validmind as vm
from validmind.tests.data_validation.IQROutliersBarPlot import IQROutliersBarPlot

df = pd.DataFrame({
    "numeric": np.random.randn(100),
    "flag": np.random.choice([True, False], 100),
})
dataset = vm.init_dataset(input_id="repro", dataset=df, __log=False)
IQROutliersBarPlot(dataset)  # should complete without error
```

## What needs special review?

- Confirm excluding boolean columns from IQR analysis is the intended behavior (IQR is not meaningful for boolean features).

## Dependencies, breaking changes, and deployment notes

- No dependencies.
- No breaking changes.
- Boolean columns will no longer appear in `IQROutliersBarPlot` output.

## Release notes

`bug`

Fixed a failure in `IQROutliersBarPlot` when datasets contain boolean feature columns. The test now skips boolean and binary features instead of raising a `numpy boolean subtract` error during IQR calculations.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied
- [x] PR linked to Shortcut
- [x] Unit tests added (Backend)
- [x] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)