### PR TITLE
[SC-16871] Make DeepEval agentic tests natively accessible within the default ValidMind test suite for Enterprise Google Gemini (Vertex AI)

### DIFF
--- a/notebooks/how_to/tests/run_tests/configure_tests/configure_judge_llms.ipynb
+++ b/notebooks/how_to/tests/run_tests/configure_tests/configure_judge_llms.ipynb
@@ -1,835 +1,774 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "id": "0935afb5",
-      "metadata": {},
-      "source": [
-        "# Configure judge LLM and judge embeddings\n",
-        "\n",
-        "This notebook shows how to configure and validate the default judge LLM and judge embeddings used by the ValidMind Library for LLM-focused tests.\n",
-        "\n",
-        "It exercises three important paths:\n",
-        "1. Prompt-validation tests, which depend on the default judge LLM.\n",
-        "2. RAGAS-based tests, which depend on both the default judge LLM and the default judge embeddings model.\n",
-        "3. DeepEval scorers, which depend on the default local scorer model path.\n",
-        "\n",
-        "The notebook automatically selects the available provider from your environment, with OpenAI taking precedence when both OpenAI and Gemini keys are set, to match the library's default-provider logic."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "1f2befa6",
-      "metadata": {},
-      "source": [
-        "::: {.content-hidden when-format=\"html\"}\n",
-        "## Contents\n",
-        "- [Introduction](#toc1__)\n",
-        "- [About ValidMind](#toc2__)\n",
-        "  - [Before you begin](#toc2_1__)\n",
-        "  - [New to ValidMind?](#toc2_2__)\n",
-        "  - [Key concepts](#toc2_3__)\n",
-        "- [Setting up](#toc3__)\n",
-        "  - [Install the ValidMind Library](#toc3_1__)\n",
-        "  - [Connect to the ValidMind Platform](#toc3_2__)\n",
-        "    - [Register or select a model](#toc3_2_1__)\n",
-        "    - [Choose a documentation template](#toc3_2_2__)\n",
-        "    - [Get your code snippet](#toc3_2_3__)\n",
-        "  - [Initialize the notebook environment](#toc3_3__)\n",
-        "- [Getting to know ValidMind](#toc4__)\n",
-        "  - [Preview the documentation template](#toc4_1__)\n",
-        "  - [View model documentation in the ValidMind Platform](#toc4_2__)\n",
-        "- [Configure the judge provider](#toc5__)\n",
-        "- [Prompt-validation tests](#toc6__)\n",
-        "- [RAGAS tests](#toc7__)\n",
-        "- [DeepEval scorers](#toc8__)\n",
-        "- [In summary](#toc9__)\n",
-        "- [Next steps](#toc10__)\n",
-        "  - [Discover more learning resources](#toc10_1__)\n",
-        "- [Upgrade ValidMind](#toc11__)\n",
-        "\n",
-        ":::\n",
-        "<!-- jn-toc-notebook-config\n",
-        "\tnumbering=false\n",
-        "\tanchor=true\n",
-        "\tflat=false\n",
-        "\tminLevel=2\n",
-        "\tmaxLevel=4\n",
-        "\t/jn-toc-notebook-config -->\n",
-        "<!-- THIS CELL WILL BE REPLACED ON TOC UPDATE. DO NOT WRITE YOUR TEXT IN THIS CELL -->"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b77005b8",
-      "metadata": {},
-      "source": [
-        "<a id='toc1__'></a>\n",
-        "\n",
-        "## Introduction\n",
-        "\n",
-        "This notebook shows how to configure and validate the default judge LLM and judge embeddings used by the ValidMind Library for LLM-focused tests.\n",
-        "\n",
-        "It walks through the provider configuration used by three important evaluation paths:\n",
-        "- prompt-validation tests\n",
-        "- RAGAS-based tests\n",
-        "- DeepEval scorers\n",
-        "\n",
-        "Along the way, you will initialize ValidMind model and dataset objects, inspect the resolved judge configuration, run representative tests, and optionally log the results to the ValidMind Platform. By the end of the notebook, you will have a practical reference for configuring judge models and understanding how those settings affect different LLM evaluation workflows."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "56ecff8d",
-      "metadata": {},
-      "source": [
-        "<a id='toc2__'></a>\n",
-        "\n",
-        "## About ValidMind\n",
-        "\n",
-        "ValidMind is a suite of tools for managing model risk, including risk associated with AI and statistical models. \n",
-        "\n",
-        "You use the ValidMind Library to automate documentation and validation tests, and then use the ValidMind Platform to collaborate on model documentation. Together, these products simplify model risk management, facilitate compliance with regulations and institutional standards, and enhance collaboration between yourself and model validators."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e8743d30",
-      "metadata": {},
-      "source": [
-        "<a id='toc2_1__'></a>\n",
-        "\n",
-        "### Before you begin\n",
-        "\n",
-        "Before running this notebook, make sure you have:\n",
-        "- a Python environment with the ValidMind Library and its LLM dependencies installed\n",
-        "- access to a ValidMind account if you want to log results to the ValidMind Platform\n",
-        "- credentials for one supported judge provider in your environment\n",
-        "\n",
-        "This notebook supports:\n",
-        "- OpenAI via `OPENAI_API_KEY`, with optional `OPENAI_MODEL` and `OPENAI_EMBEDDINGS_MODEL` overrides. The current default judge model is `gpt-4.1` and the default embeddings model is `text-embedding-3-small`.\n",
-        "- Gemini via `GOOGLE_API_KEY` or `GEMINI_API_KEY`, with optional `GEMINI_MODEL` and `GEMINI_EMBEDDINGS_MODEL` overrides. The current defaults are `gemini-2.5-pro` and `models/text-embedding-004`.\n",
-        "- Azure OpenAI via `AZURE_OPENAI_KEY`, `AZURE_OPENAI_ENDPOINT`, and `AZURE_OPENAI_MODEL`. The current default embeddings model is `text-embedding-3-small`.\n",
-        "\n",
-        "You can still run the notebook locally without connecting to the ValidMind Platform, but connecting a model document makes it easier to review and share results after the tests complete."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "ee479eb5",
-      "metadata": {},
-      "source": [
-        "<a id='toc2_2__'></a>\n",
-        "\n",
-        "### New to ValidMind?\n",
-        "\n",
-        "If you are new to the ValidMind Library, start with the [ValidMind Library overview](https://docs.validmind.ai/developer/validmind-library.html). It introduces the core workflow for initializing models and datasets, running tests, and logging outputs back to the ValidMind Platform.\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\" style=\"background-color: #B5B5B510; color: black; border: 1px solid #083E44; border-left-width: 5px; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);border-radius: 5px;\"><span style=\"color: #083E44;\"><b>You only need a ValidMind account if you want to log results to the ValidMind Platform.</b></span>\n",
-        "<br></br>\n",
-        "<a href=\"https://docs.validmind.ai/guide/access/register-with-validmind.html\" style=\"color: #DE257E;\"><b>Register with ValidMind</b></a></div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "689e55db",
-      "metadata": {},
-      "source": [
-        "<a id='toc2_3__'></a>\n",
-        "\n",
-        "### Key concepts\n",
-        "\n",
-        "**Judge LLM**: The language model used by ValidMind to evaluate prompts, answers, contexts, and other LLM outputs.\n",
-        "\n",
-        "**Judge embeddings**: The embeddings model used when a test requires semantic similarity or retrieval-based comparison.\n",
-        "\n",
-        "**Provider credentials**: Environment variables that tell ValidMind which provider to use for judge evaluation. In this notebook, the provider is resolved automatically from the credentials available in your environment.\n",
-        "\n",
-        "**ValidMind dataset**: A dataset initialized with [`vm.init_dataset()`](https://docs.validmind.ai/validmind/validmind.html#init_dataset). Wrapping a pandas DataFrame this way lets you pass the dataset into ValidMind tests with the metadata those tests expect.\n",
-        "\n",
-        "**ValidMind model**: A model initialized with [`vm.init_model()`](https://docs.validmind.ai/validmind/validmind.html#init_model). In this notebook, we use a lightweight model object to run prompt-validation tests against a prompt template.\n",
-        "\n",
-        "**Prompt-validation tests**: Tests that evaluate prompt quality and instructions, such as clarity or bias, using a judge LLM.\n",
-        "\n",
-        "**RAGAS tests**: Retrieval-augmented generation tests that can rely on both a judge LLM and judge embeddings.\n",
-        "\n",
-        "**DeepEval scorers**: LLM-based scorers used for tasks such as answer relevancy and hallucination detection. These use the evaluation model path but do not require judge embeddings."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "322b05cc",
-      "metadata": {},
-      "source": [
-        "<a id='toc3__'></a>\n",
-        "\n",
-        "## Setting up"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "8d6a8300",
-      "metadata": {},
-      "source": [
-        "<a id='toc3_1__'></a>\n",
-        "\n",
-        "### Install the ValidMind Library\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\" style=\"background-color: #B5B5B510; color: black; border: 1px solid #083E44; border-left-width: 5px; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);border-radius: 5px;\"><span style=\"color: #083E44;\"><b>Recommended Python versions</b></span>\n",
-        "<br></br>\n",
-        "Python 3.8 <= x <= 3.14</div>\n",
-        "\n",
-        "Install the ValidMind Library with the optional LLM dependencies so the notebook can run prompt-validation tests, RAGAS tests, and DeepEval scorers:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "da644666",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%pip install -q \"validmind[llm]\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "17c1c7d2",
-      "metadata": {},
-      "source": [
-        "<a id='toc3_2__'></a>\n",
-        "\n",
-        "### Connect to the ValidMind Platform\n",
-        "\n",
-        "If you want to log notebook outputs to the ValidMind Platform, start by selecting an existing model in your inventory or registering a new one. This notebook can run without platform connectivity, but linking it to a model document gives you a place to review the results after the examples finish.\n",
-        "\n",
-        "<a id='toc3_2_1__'></a>\n",
-        "\n",
-        "#### Register or select a model\n",
-        "\n",
-        "1. In a browser, [log in to ValidMind](https://docs.validmind.ai/guide/access/log-in-to-validmind.html).\n",
-        "\n",
-        "2. In the left sidebar, select **Inventory**.\n",
-        "\n",
-        "3. Select `Model` by clicking on **{Record} Inventory**, where `{Record}` is the currently active type of record.\n",
-        "\n",
-        "4. Either select an existing model from the list, or click **+ Register Model** to register a new one.\n",
-        "\n",
-        "5. Complete the model details and stakeholder assignments if you are registering a new model.\n",
-        "\n",
-        "6. Open the document where you want notebook results to be logged.\n",
-        "\n",
-        "Using a real model document is especially helpful in this notebook because it lets you compare the locally executed tests with the sections available in your template."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "dc628c6c",
-      "metadata": {},
-      "source": [
-        "<a id='toc3_2_2__'></a>\n",
-        "\n",
-        "#### Choose a documentation template\n",
-        "\n",
-        "If you plan to log results from this notebook, make sure your model document uses a template that includes sections for the LLM evaluation results you want to capture.\n",
-        "\n",
-        "This is important because tests that are not included in the selected template will not appear automatically in the Platform document, even if you run and log them successfully from the notebook. If you want to document those results as well, you can add the relevant sections or tests manually in the Platform.\n",
-        "\n",
-        "Before running the notebook, preview the template structure and confirm that the document has the sections you expect for your workflow."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "702f5196",
-      "metadata": {},
-      "source": [
-        "<a id='toc3_2_3__'></a>\n",
-        "\n",
-        "#### Get your code snippet\n",
-        "\n",
-        "Initialize the ValidMind Library with the code snippet associated with your model document so that test results are uploaded to the correct destination in the ValidMind Platform.\n",
-        "\n",
-        "1. In the model sidebar, open **Getting Started**.\n",
-        "2. Select the document you want to update.\n",
-        "3. Copy the generated code snippet.\n",
-        "4. Load the values from an `.env` file or replace the placeholders in the example below with your own values.\n",
-        "\n",
-        "Using environment variables is usually the easiest way to keep the notebook portable across environments and avoid hard-coding connection details in the notebook itself."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "c52a42d0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Load your model identifier credentials from an `.env` file\n",
-        "\n",
-        "%load_ext dotenv\n",
-        "%dotenv .env\n",
-        "\n",
-        "# Or replace with your code snippet\n",
-        "\n",
-        "import validmind as vm\n",
-        "\n",
-        "vm.init(\n",
-        "    api_host=\"https://app.prod.validmind.ai/api/v1/tracking\",\n",
-        "    api_key=\"...\",\n",
-        "    api_secret=\"...\",\n",
-        "    document=\"documentation\", # requires library >=2.12.0\n",
-        "    model=\"...\",\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "3657a7a4",
-      "metadata": {},
-      "source": [
-        "<a id='toc3_3__'></a>\n",
-        "\n",
-        "### Initialize the notebook environment\n",
-        "\n",
-        "Load environment variables and prepare the notebook session. In the execution cells that follow, you will import the libraries needed for this walkthrough, inspect the configured judge provider, and create the ValidMind objects used by the example tests.\n",
-        "\n",
-        "This section is also where the notebook becomes reproducible: once your credentials and dependencies are in place, the remaining sections can be run top to bottom."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "979988a9",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "\n",
-        "import pandas as pd\n",
-        "\n",
-        "from validmind.ai import utils as ai_utils\n",
-        "from validmind.models import Prompt\n",
-        "from validmind.tests import run_test"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "3db58d74",
-      "metadata": {},
-      "source": [
-        "<a id='toc4__'></a>\n",
-        "\n",
-        "## Getting to know ValidMind"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "45450d55",
-      "metadata": {},
-      "source": [
-        "<a id='toc4_1__'></a>\n",
-        "\n",
-        "### Preview the documentation template\n",
-        "\n",
-        "If you have already connected this notebook to a model document, you can preview the active template structure directly from the library.\n",
-        "\n",
-        "This is useful for confirming where logged results will appear before you run the prompt-validation, RAGAS, and DeepEval examples below. It also helps you spot gaps early if a test you plan to run is not represented in the current template:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "98f0b602",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "vm.preview_template()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "58e1d75f",
-      "metadata": {},
-      "source": [
-        "<a id='toc4_2__'></a>\n",
-        "\n",
-        "### View model documentation in the ValidMind Platform\n",
-        "\n",
-        "After you run the notebook and log results, open your model document in the ValidMind Platform to review how the test outputs were added.\n",
-        "\n",
-        "Comparing the template preview with the rendered document is a good way to confirm that your notebook is writing results to the expected sections. If a result does not appear automatically, check whether the corresponding test is part of the selected template before troubleshooting the notebook run itself."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "86038351",
-      "metadata": {},
-      "source": [
-        "<a id='toc5__'></a>\n",
-        "\n",
-        "## Configure the judge provider\n",
-        "\n",
-        "The next cells load your environment variables, resolve the judge provider from the credentials available in your session, and initialize the ValidMind Library for result logging.\n",
-        "\n",
-        "This notebook uses the same provider resolution logic as the library itself:\n",
-        "- OpenAI is selected when `OPENAI_API_KEY` is available, with `OPENAI_MODEL` as an optional override. The current default judge model is `gpt-4.1`.\n",
-        "- Azure OpenAI is selected when Azure credentials are available, using `AZURE_OPENAI_MODEL` for the judge model.\n",
-        "- Gemini is selected when `GOOGLE_API_KEY` or `GEMINI_API_KEY` is available, with optional `GEMINI_MODEL` and `GEMINI_EMBEDDINGS_MODEL` overrides. The current defaults are `gemini-2.5-pro` and `models/text-embedding-004`.\n",
-        "\n",
-        "If more than one provider is configured, OpenAI takes precedence to match the library default.\n",
-        "\n",
-        "This matters because the same default judge configuration is reused across multiple evaluation paths, so checking it once here makes the later test results easier to interpret."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a3efda1f",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Optional: override the default judge models for this notebook session.\n",
-        "# os.environ[\"OPENAI_MODEL\"] = \"gpt-4.1\"\n",
-        "# os.environ[\"GEMINI_MODEL\"] = \"gemini-2.5-pro\"\n",
-        "# os.environ[\"GEMINI_EMBEDDINGS_MODEL\"] = \"models/text-embedding-004\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f0438cf0",
-      "metadata": {},
-      "source": [
-        "The next cells import the required libraries, inspect the resolved provider configuration, and connect the notebook to the ValidMind Platform. Reading the printed provider and class names is a quick sanity check that your environment is using the judge setup you expect before any tests are executed."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "089f10fa",
-      "metadata": {},
-      "source": [
-        "<a id='toc5_1__'></a>\n",
-        "\n",
-        "### Load credentials and resolve the provider\n",
-        "\n",
-        "Run the next cells to:\n",
-        "- import the libraries used in this notebook\n",
-        "- inspect the provider selected from your environment\n",
-        "- inspect the resolved judge LLM and judge embeddings classes\n",
-        "- initialize the ValidMind Library with your platform credentials\n",
-        "\n",
-        "If both OpenAI and Gemini credentials are available, OpenAI will be selected to match the default provider precedence used by the library.\n",
-        "\n",
-        "This section gives you a concrete view of the effective configuration that the later prompt-validation, RAGAS, and DeepEval examples will use."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "f1479922",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from validmind.ai.utils import get_client_and_model, get_judge_config\n",
-        "\n",
-        "client, model = get_client_and_model()\n",
-        "judge_llm, judge_embeddings = get_judge_config()\n",
-        "\n",
-        "print(\"resolved_model:\", model)\n",
-        "print(\"judge_llm_type:\", type(judge_llm).__name__)\n",
-        "print(\"judge_embeddings_type:\", type(judge_embeddings).__name__)\n",
-        "\n",
-        "# Useful for Gemini/OpenAI/Azure debugging\n",
-        "print(\"judge_llm:\", judge_llm)\n",
-        "print(\"judge_embeddings:\", judge_embeddings)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e7868c71",
-      "metadata": {},
-      "source": [
-        "<a id='toc6__'></a>\n",
-        "\n",
-        "## Prompt-validation tests\n",
-        "\n",
-        "This section validates the default judge LLM path with two representative prompt-validation tests. For this smoke test, we use a simple prompt-only model because these tests evaluate the prompt template itself and do not require model predictions.\n",
-        "\n",
-        "The example below creates a ValidMind model with `vm.init_model()` and attaches a prompt template to it. That gives the tests a standard object to inspect, even though there is no real predictive model behind the example.\n",
-        "\n",
-        "- `Clarity` checks whether the prompt instructions are clear and well-scoped.\n",
-        "- `Bias` checks whether the prompt structure or examples could induce biased behavior."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "7cc07ba8",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "system_prompt = \"\"\"\n",
-        "You are an AI assistant specialized in sentiment analysis for financial news.\n",
-        "You will classify each sentence as positive, negative, or neutral.\n",
-        "Respond only with the sentiment label.\n",
-        "\"\"\".strip()\n",
-        "\n",
-        "\n",
-        "def noop_predict(_):\n",
-        "    return \"dummy\"\n",
-        "\n",
-        "\n",
-        "vm_prompt_model = vm.init_model(\n",
-        "    input_id=\"judge_prompt_model\",\n",
-        "    predict_fn=noop_predict,\n",
-        "    prompt=Prompt(template=system_prompt, variables=[]),\n",
-        ")\n",
-        "\n",
-        "vm_prompt_model.prompt.template"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "40298f6b",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run_test(\n",
-        "    test_id=\"validmind.prompt_validation.Clarity\",\n",
-        "    inputs={\"model\": vm_prompt_model},\n",
-        ").log()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "4180b0f1",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run_test(\n",
-        "    test_id=\"validmind.prompt_validation.Bias\",\n",
-        "    inputs={\"model\": vm_prompt_model},\n",
-        ").log()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "9935d075",
-      "metadata": {},
-      "source": [
-        "<a id='toc7__'></a>\n",
-        "\n",
-        "## RAGAS tests\n",
-        "\n",
-        "This section validates the default judge LLM plus default judge embeddings path. The selected tests are useful because they exercise the RAGAS integration that historically depended on the default OpenAI setup.\n",
-        "\n",
-        "The example data is wrapped with `vm.init_dataset()`, which turns the pandas DataFrame into a ValidMind dataset object that can be passed directly into these tests.\n",
-        "\n",
-        "- `ResponseRelevancy` exercises the judge LLM and embeddings path.\n",
-        "- `AnswerCorrectness` exercises semantic and factual comparison with judge embeddings.\n",
-        "- `Faithfulness` is a companion smoke test for the judge LLM path on RAG data.\n",
-        "\n",
-        "These tests produce Plotly figures, so this notebook focuses on running and logging the results rather than comparing visual output in detail."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "17cbf0e3",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "rag_df = pd.DataFrame(\n",
-        "    {\n",
-        "        \"user_input\": [\n",
-        "            \"What happened to the company's revenue guidance?\",\n",
-        "            \"Why did the bank's stock decline?\",\n",
-        "            \"What was the announced dividend decision?\",\n",
-        "        ],\n",
-        "        \"retrieved_contexts\": [\n",
-        "            [\n",
-        "                \"The company raised its full-year revenue guidance after reporting strong demand in the enterprise segment.\",\n",
-        "                \"Management said the improved forecast was driven by larger-than-expected renewals.\",\n",
-        "            ],\n",
-        "            [\n",
-        "                \"The bank's stock declined after it reported higher-than-expected credit losses in its consumer portfolio.\",\n",
-        "                \"Executives also warned that provisions may remain elevated next quarter.\",\n",
-        "            ],\n",
-        "            [\n",
-        "                \"The board announced that it would keep the quarterly dividend unchanged.\",\n",
-        "                \"Management said capital return policy remains the same for now.\",\n",
-        "            ],\n",
-        "        ],\n",
-        "        \"response\": [\n",
-        "            \"The company increased its full-year revenue guidance after stronger enterprise demand.\",\n",
-        "            \"The bank's stock fell because it disclosed higher-than-expected credit losses.\",\n",
-        "            \"The company kept its dividend unchanged.\",\n",
-        "        ],\n",
-        "        \"reference\": [\n",
-        "            \"The company raised its full-year revenue guidance because demand in the enterprise segment was strong.\",\n",
-        "            \"The bank's shares dropped after it reported higher-than-expected credit losses.\",\n",
-        "            \"The board decided to leave the quarterly dividend unchanged.\",\n",
-        "        ],\n",
-        "    }\n",
-        ")\n",
-        "\n",
-        "vm_rag_ds = vm.init_dataset(\n",
-        "    dataset=rag_df,\n",
-        "    input_id=\"judge_rag_dataset\",\n",
-        "    text_column=\"user_input\",\n",
-        "    target_column=\"reference\",\n",
-        ")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "fcdb6232",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run_test(\n",
-        "    test_id=\"validmind.model_validation.ragas.ResponseRelevancy\",\n",
-        "    inputs={\"dataset\": vm_rag_ds},\n",
-        ").log()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "25124a2f",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run_test(\n",
-        "    test_id=\"validmind.model_validation.ragas.AnswerCorrectness\",\n",
-        "    inputs={\"dataset\": vm_rag_ds},\n",
-        ").log()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3a58bd42",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run_test(\n",
-        "    test_id=\"validmind.model_validation.ragas.Faithfulness\",\n",
-        "    inputs={\"dataset\": vm_rag_ds},\n",
-        ").log()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "8b65420f",
-      "metadata": {},
-      "source": [
-        "<a id='toc8__'></a>\n",
-        "\n",
-        "## DeepEval scorers\n",
-        "\n",
-        "This section validates the default local scorer model path used by DeepEval-based scorers in `validmind.scorers.llm.deepeval`.\n",
-        "\n",
-        "As in the RAGAS example, we create a ValidMind dataset with `vm.init_dataset()` so the scorer workflow runs against the same kind of object customers would use in their own notebooks.\n",
-        "\n",
-        "These scorers do not use the judge embeddings object. For this notebook, we use two representative examples:\n",
-        "- `AnswerRelevancy`\n",
-        "- `Hallucination`\n",
-        "\n",
-        "They are included here so the notebook covers all three LLM evaluation surfaces:\n",
-        "- prompt-validation\n",
-        "- RAGAS\n",
-        "- DeepEval scorers"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "c34f2484",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "deepeval_df = pd.DataFrame(\n",
-        "    {\n",
-        "        \"input\": [\n",
-        "            \"What is the capital of France?\",\n",
-        "            \"Why did the company raise its full-year guidance?\",\n",
-        "            \"What did the board decide about the quarterly dividend?\",\n",
-        "        ],\n",
-        "        \"actual_output\": [\n",
-        "            \"The capital of France is Paris.\",\n",
-        "            \"The company raised guidance because enterprise demand was stronger than expected.\",\n",
-        "            \"The board kept the quarterly dividend unchanged.\",\n",
-        "        ],\n",
-        "        \"context\": [\n",
-        "            [\"France's capital city is Paris.\"],\n",
-        "            [\n",
-        "                \"Management raised its full-year guidance after reporting stronger-than-expected demand in the enterprise segment.\"\n",
-        "            ],\n",
-        "            [\n",
-        "                \"The board announced that the quarterly dividend would remain unchanged.\"\n",
-        "            ],\n",
-        "        ],\n",
-        "    }\n",
-        ")\n",
-        "\n",
-        "vm_deepeval_ds = vm.init_dataset(\n",
-        "    dataset=deepeval_df,\n",
-        "    input_id=\"judge_deepeval_dataset\",\n",
-        "    text_column=\"input\",\n",
-        "    target_column=\"actual_output\",\n",
-        ")\n",
-        "\n",
-        "deepeval_df"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9a3cdae0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "vm_deepeval_ds.assign_scores(metrics=[\n",
-        "    \"validmind.scorers.llm.deepeval.Hallucination\",\n",
-        "    \"validmind.scorers.llm.deepeval.AnswerRelevancy\"\n",
-        "])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "d86a90ab",
-      "metadata": {},
-      "source": [
-        "<a id='toc9__'></a>\n",
-        "\n",
-        "## In summary\n",
-        "\n",
-        "In this notebook, you learned how to:\n",
-        "- [x] configure the judge provider from environment credentials\n",
-        "- [x] override the default judge LLM and judge embeddings models\n",
-        "- [x] initialize ValidMind model and dataset objects for LLM evaluation workflows\n",
-        "- [x] run prompt-validation tests that use the judge LLM\n",
-        "- [x] run RAGAS tests that use the judge LLM and judge embeddings\n",
-        "- [x] run DeepEval scorers that use the local scorer model path"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c7b72b3e",
-      "metadata": {},
-      "source": [
-        "<a id='toc10__'></a>\n",
-        "\n",
-        "## Next steps\n",
-        "\n",
-        "You can use this notebook as a starting point for your own LLM evaluation workflows. A few practical follow-ups are:\n",
-        "- replace the sample prompt and datasets with your own evaluation inputs\n",
-        "- set `OPENAI_MODEL` / `OPENAI_EMBEDDINGS_MODEL` when you want to override the OpenAI judge pair, or `GEMINI_MODEL` / `GEMINI_EMBEDDINGS_MODEL` when you want to standardize the Gemini judge pair used across notebooks or environments\n",
-        "- expand the set of tests and scorers based on your use case"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "e5eb12d8",
-      "metadata": {},
-      "source": [
-        "<a id='toc10_1__'></a>\n",
-        "\n",
-        "### Discover more learning resources\n",
-        "\n",
-        "To continue learning about testing and evaluation with the ValidMind Library, explore:\n",
-        "\n",
-        "- [Run tests and test suites](https://docs.validmind.ai/developer/how-to/testing-overview.html)\n",
-        "- [ValidMind Library overview](https://docs.validmind.ai/developer/validmind-library.html)\n",
-        "- [Use ValidMind Library features](https://docs.validmind.ai/developer/how-to/feature-overview.html)\n",
-        "- [Code samples by use case](https://docs.validmind.ai/guide/samples-jupyter-notebooks.html)\n",
-        "\n",
-        "You can also visit the [ValidMind documentation](https://docs.validmind.ai/) for broader guidance on configuration, testing workflows, and model documentation."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "99a11a0e",
-      "metadata": {},
-      "source": [
-        "<a id='toc11__'></a>\n",
-        "\n",
-        "## Upgrade ValidMind\n",
-        "\n",
-        "<div class=\"alert alert-block alert-info\" style=\"background-color: #B5B5B510; color: black; border: 1px solid #083E44; border-left-width: 5px; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);border-radius: 5px;\">After installing ValidMind, periodically check that you are using a recent version so you can access the latest provider integrations, tests, and product improvements.</div>\n",
-        "\n",
-        "Retrieve the information for the currently installed version of ValidMind:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cfed92f5",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "%pip show validmind"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "58cc2437",
-      "metadata": {},
-      "source": [
-        "If the version returned is lower than the version indicated in our [production open-source code](https://github.com/validmind/validmind-library/blob/prod/validmind/__version__.py), restart your notebook and run:\n",
-        "\n",
-        "```bash\n",
-        "%pip install --upgrade validmind\n",
-        "```"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "aa5c4672",
-      "metadata": {},
-      "source": [
-        "You may need to restart your kernel after running the upgrade package for changes to be applied."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "copyright-fe0b013da3464949b043e9dbdd34b608",
-      "metadata": {},
-      "source": [
-        "<!-- VALIDMIND COPYRIGHT -->\n",
-        "\n",
-        "<small>\n",
-        "\n",
-        "***\n",
-        "\n",
-        "Copyright © 2023-2026 ValidMind Inc. All rights reserved.<br>\n",
-        "Refer to [LICENSE](https://github.com/validmind/validmind-library/blob/main/LICENSE) for details.<br>\n",
-        "SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial</small>"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": ".venv-py31111",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.11.11"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0935afb5",
+   "metadata": {},
+   "source": "# Configure judge LLM and judge embeddings\n\nThis notebook shows how to configure and validate the default judge LLM and judge embeddings used by the ValidMind Library for LLM-focused tests.\n\nIt exercises three important paths:\n1. Prompt-validation tests, which depend on the default judge LLM.\n2. RAGAS-based tests, which depend on both the default judge LLM and the default judge embeddings model.\n3. DeepEval scorers, which use the judge LLM configured via `set_judge_config()`.\n\nThe notebook automatically selects the available provider from your environment, with OpenAI taking precedence when both OpenAI and Gemini keys are set, to match the library's default-provider logic."
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "1f2befa6",
+   "metadata": {},
+   "source": [
+    "::: {.content-hidden when-format=\"html\"}\n",
+    "## Contents\n",
+    "- [Introduction](#toc1__)\n",
+    "- [About ValidMind](#toc2__)\n",
+    "  - [Before you begin](#toc2_1__)\n",
+    "  - [New to ValidMind?](#toc2_2__)\n",
+    "  - [Key concepts](#toc2_3__)\n",
+    "- [Setting up](#toc3__)\n",
+    "  - [Install the ValidMind Library](#toc3_1__)\n",
+    "  - [Connect to the ValidMind Platform](#toc3_2__)\n",
+    "    - [Register or select a model](#toc3_2_1__)\n",
+    "    - [Choose a documentation template](#toc3_2_2__)\n",
+    "    - [Get your code snippet](#toc3_2_3__)\n",
+    "  - [Initialize the notebook environment](#toc3_3__)\n",
+    "- [Getting to know ValidMind](#toc4__)\n",
+    "  - [Preview the documentation template](#toc4_1__)\n",
+    "  - [View model documentation in the ValidMind Platform](#toc4_2__)\n",
+    "- [Configure the judge provider](#toc5__)\n",
+    "- [Prompt-validation tests](#toc6__)\n",
+    "- [RAGAS tests](#toc7__)\n",
+    "- [DeepEval scorers](#toc8__)\n",
+    "- [In summary](#toc9__)\n",
+    "- [Next steps](#toc10__)\n",
+    "  - [Discover more learning resources](#toc10_1__)\n",
+    "- [Upgrade ValidMind](#toc11__)\n",
+    "\n",
+    ":::\n",
+    "<!-- jn-toc-notebook-config\n",
+    "\tnumbering=false\n",
+    "\tanchor=true\n",
+    "\tflat=false\n",
+    "\tminLevel=2\n",
+    "\tmaxLevel=4\n",
+    "\t/jn-toc-notebook-config -->\n",
+    "<!-- THIS CELL WILL BE REPLACED ON TOC UPDATE. DO NOT WRITE YOUR TEXT IN THIS CELL -->"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b77005b8",
+   "metadata": {},
+   "source": [
+    "<a id='toc1__'></a>\n",
+    "\n",
+    "## Introduction\n",
+    "\n",
+    "This notebook shows how to configure and validate the default judge LLM and judge embeddings used by the ValidMind Library for LLM-focused tests.\n",
+    "\n",
+    "It walks through the provider configuration used by three important evaluation paths:\n",
+    "- prompt-validation tests\n",
+    "- RAGAS-based tests\n",
+    "- DeepEval scorers\n",
+    "\n",
+    "Along the way, you will initialize ValidMind model and dataset objects, inspect the resolved judge configuration, run representative tests, and optionally log the results to the ValidMind Platform. By the end of the notebook, you will have a practical reference for configuring judge models and understanding how those settings affect different LLM evaluation workflows."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56ecff8d",
+   "metadata": {},
+   "source": [
+    "<a id='toc2__'></a>\n",
+    "\n",
+    "## About ValidMind\n",
+    "\n",
+    "ValidMind is a suite of tools for managing model risk, including risk associated with AI and statistical models. \n",
+    "\n",
+    "You use the ValidMind Library to automate documentation and validation tests, and then use the ValidMind Platform to collaborate on model documentation. Together, these products simplify model risk management, facilitate compliance with regulations and institutional standards, and enhance collaboration between yourself and model validators."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8743d30",
+   "metadata": {},
+   "source": [
+    "<a id='toc2_1__'></a>\n",
+    "\n",
+    "### Before you begin\n",
+    "\n",
+    "Before running this notebook, make sure you have:\n",
+    "- a Python environment with the ValidMind Library and its LLM dependencies installed\n",
+    "- access to a ValidMind account if you want to log results to the ValidMind Platform\n",
+    "- credentials for one supported judge provider in your environment\n",
+    "\n",
+    "This notebook supports:\n",
+    "- OpenAI via `OPENAI_API_KEY`, with optional `OPENAI_MODEL` and `OPENAI_EMBEDDINGS_MODEL` overrides. The current default judge model is `gpt-4.1` and the default embeddings model is `text-embedding-3-small`.\n",
+    "- Gemini via `GOOGLE_API_KEY` or `GEMINI_API_KEY`, with optional `GEMINI_MODEL` and `GEMINI_EMBEDDINGS_MODEL` overrides. The current defaults are `gemini-2.5-pro` and `models/text-embedding-004`.\n",
+    "- Azure OpenAI via `AZURE_OPENAI_KEY`, `AZURE_OPENAI_ENDPOINT`, and `AZURE_OPENAI_MODEL`. The current default embeddings model is `text-embedding-3-small`.\n",
+    "\n",
+    "You can still run the notebook locally without connecting to the ValidMind Platform, but connecting a model document makes it easier to review and share results after the tests complete."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee479eb5",
+   "metadata": {},
+   "source": [
+    "<a id='toc2_2__'></a>\n",
+    "\n",
+    "### New to ValidMind?\n",
+    "\n",
+    "If you are new to the ValidMind Library, start with the [ValidMind Library overview](https://docs.validmind.ai/developer/validmind-library.html). It introduces the core workflow for initializing models and datasets, running tests, and logging outputs back to the ValidMind Platform.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\" style=\"background-color: #B5B5B510; color: black; border: 1px solid #083E44; border-left-width: 5px; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);border-radius: 5px;\"><span style=\"color: #083E44;\"><b>You only need a ValidMind account if you want to log results to the ValidMind Platform.</b></span>\n",
+    "<br></br>\n",
+    "<a href=\"https://docs.validmind.ai/guide/access/register-with-validmind.html\" style=\"color: #DE257E;\"><b>Register with ValidMind</b></a></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "689e55db",
+   "metadata": {},
+   "source": "<a id='toc2_3__'></a>\n\n### Key concepts\n\n**Judge LLM**: The language model used by ValidMind to evaluate prompts, answers, contexts, and other LLM outputs.\n\n**Judge embeddings**: The embeddings model used when a test requires semantic similarity or retrieval-based comparison.\n\n**Provider credentials**: Environment variables that tell ValidMind which provider to use for judge evaluation. In this notebook, the provider is resolved automatically from the credentials available in your environment.\n\n**ValidMind dataset**: A dataset initialized with [`vm.init_dataset()`](https://docs.validmind.ai/validmind/validmind.html#init_dataset). Wrapping a pandas DataFrame this way lets you pass the dataset into ValidMind tests with the metadata those tests expect.\n\n**ValidMind model**: A model initialized with [`vm.init_model()`](https://docs.validmind.ai/validmind/validmind.html#init_model). In this notebook, we use a lightweight model object to run prompt-validation tests against a prompt template.\n\n**Prompt-validation tests**: Tests that evaluate prompt quality and instructions, such as clarity or bias, using a judge LLM.\n\n**RAGAS tests**: Retrieval-augmented generation tests that can rely on both a judge LLM and judge embeddings.\n\n**DeepEval scorers**: LLM-based scorers used for tasks such as answer relevancy and hallucination detection. These use the judge LLM configured via `set_judge_config()` and do not require judge embeddings."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "322b05cc",
+   "metadata": {},
+   "source": [
+    "<a id='toc3__'></a>\n",
+    "\n",
+    "## Setting up"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d6a8300",
+   "metadata": {},
+   "source": [
+    "<a id='toc3_1__'></a>\n",
+    "\n",
+    "### Install the ValidMind Library\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\" style=\"background-color: #B5B5B510; color: black; border: 1px solid #083E44; border-left-width: 5px; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);border-radius: 5px;\"><span style=\"color: #083E44;\"><b>Recommended Python versions</b></span>\n",
+    "<br></br>\n",
+    "Python 3.8 <= x <= 3.14</div>\n",
+    "\n",
+    "Install the ValidMind Library with the optional LLM dependencies so the notebook can run prompt-validation tests, RAGAS tests, and DeepEval scorers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da644666",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -q \"validmind[llm]\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17c1c7d2",
+   "metadata": {},
+   "source": [
+    "<a id='toc3_2__'></a>\n",
+    "\n",
+    "### Connect to the ValidMind Platform\n",
+    "\n",
+    "If you want to log notebook outputs to the ValidMind Platform, start by selecting an existing model in your inventory or registering a new one. This notebook can run without platform connectivity, but linking it to a model document gives you a place to review the results after the examples finish.\n",
+    "\n",
+    "<a id='toc3_2_1__'></a>\n",
+    "\n",
+    "#### Register or select a model\n",
+    "\n",
+    "1. In a browser, [log in to ValidMind](https://docs.validmind.ai/guide/access/log-in-to-validmind.html).\n",
+    "\n",
+    "2. In the left sidebar, select **Inventory**.\n",
+    "\n",
+    "3. Select `Model` by clicking on **{Record} Inventory**, where `{Record}` is the currently active type of record.\n",
+    "\n",
+    "4. Either select an existing model from the list, or click **+ Register Model** to register a new one.\n",
+    "\n",
+    "5. Complete the model details and stakeholder assignments if you are registering a new model.\n",
+    "\n",
+    "6. Open the document where you want notebook results to be logged.\n",
+    "\n",
+    "Using a real model document is especially helpful in this notebook because it lets you compare the locally executed tests with the sections available in your template."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc628c6c",
+   "metadata": {},
+   "source": [
+    "<a id='toc3_2_2__'></a>\n",
+    "\n",
+    "#### Choose a documentation template\n",
+    "\n",
+    "If you plan to log results from this notebook, make sure your model document uses a template that includes sections for the LLM evaluation results you want to capture.\n",
+    "\n",
+    "This is important because tests that are not included in the selected template will not appear automatically in the Platform document, even if you run and log them successfully from the notebook. If you want to document those results as well, you can add the relevant sections or tests manually in the Platform.\n",
+    "\n",
+    "Before running the notebook, preview the template structure and confirm that the document has the sections you expect for your workflow."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "702f5196",
+   "metadata": {},
+   "source": [
+    "<a id='toc3_2_3__'></a>\n",
+    "\n",
+    "#### Get your code snippet\n",
+    "\n",
+    "Initialize the ValidMind Library with the code snippet associated with your model document so that test results are uploaded to the correct destination in the ValidMind Platform.\n",
+    "\n",
+    "1. In the model sidebar, open **Getting Started**.\n",
+    "2. Select the document you want to update.\n",
+    "3. Copy the generated code snippet.\n",
+    "4. Load the values from an `.env` file or replace the placeholders in the example below with your own values.\n",
+    "\n",
+    "Using environment variables is usually the easiest way to keep the notebook portable across environments and avoid hard-coding connection details in the notebook itself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c52a42d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load your model identifier credentials from an `.env` file\n",
+    "\n",
+    "%load_ext dotenv\n",
+    "%dotenv .env\n",
+    "\n",
+    "# Or replace with your code snippet\n",
+    "\n",
+    "import validmind as vm\n",
+    "\n",
+    "vm.init(\n",
+    "    api_host=\"https://app.prod.validmind.ai/api/v1/tracking\",\n",
+    "    api_key=\"...\",\n",
+    "    api_secret=\"...\",\n",
+    "    document=\"documentation\", # requires library >=2.12.0\n",
+    "    model=\"...\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3657a7a4",
+   "metadata": {},
+   "source": [
+    "<a id='toc3_3__'></a>\n",
+    "\n",
+    "### Initialize the notebook environment\n",
+    "\n",
+    "Load environment variables and prepare the notebook session. In the execution cells that follow, you will import the libraries needed for this walkthrough, inspect the configured judge provider, and create the ValidMind objects used by the example tests.\n",
+    "\n",
+    "This section is also where the notebook becomes reproducible: once your credentials and dependencies are in place, the remaining sections can be run top to bottom."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "979988a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "from validmind.ai import utils as ai_utils\n",
+    "from validmind.models import Prompt\n",
+    "from validmind.tests import run_test"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3db58d74",
+   "metadata": {},
+   "source": [
+    "<a id='toc4__'></a>\n",
+    "\n",
+    "## Getting to know ValidMind"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45450d55",
+   "metadata": {},
+   "source": [
+    "<a id='toc4_1__'></a>\n",
+    "\n",
+    "### Preview the documentation template\n",
+    "\n",
+    "If you have already connected this notebook to a model document, you can preview the active template structure directly from the library.\n",
+    "\n",
+    "This is useful for confirming where logged results will appear before you run the prompt-validation, RAGAS, and DeepEval examples below. It also helps you spot gaps early if a test you plan to run is not represented in the current template:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98f0b602",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vm.preview_template()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58e1d75f",
+   "metadata": {},
+   "source": [
+    "<a id='toc4_2__'></a>\n",
+    "\n",
+    "### View model documentation in the ValidMind Platform\n",
+    "\n",
+    "After you run the notebook and log results, open your model document in the ValidMind Platform to review how the test outputs were added.\n",
+    "\n",
+    "Comparing the template preview with the rendered document is a good way to confirm that your notebook is writing results to the expected sections. If a result does not appear automatically, check whether the corresponding test is part of the selected template before troubleshooting the notebook run itself."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86038351",
+   "metadata": {},
+   "source": [
+    "<a id='toc5__'></a>\n",
+    "\n",
+    "## Configure the judge provider\n",
+    "\n",
+    "The next cells load your environment variables, resolve the judge provider from the credentials available in your session, and initialize the ValidMind Library for result logging.\n",
+    "\n",
+    "This notebook uses the same provider resolution logic as the library itself:\n",
+    "- OpenAI is selected when `OPENAI_API_KEY` is available, with `OPENAI_MODEL` as an optional override. The current default judge model is `gpt-4.1`.\n",
+    "- Azure OpenAI is selected when Azure credentials are available, using `AZURE_OPENAI_MODEL` for the judge model.\n",
+    "- Gemini is selected when `GOOGLE_API_KEY` or `GEMINI_API_KEY` is available, with optional `GEMINI_MODEL` and `GEMINI_EMBEDDINGS_MODEL` overrides. The current defaults are `gemini-2.5-pro` and `models/text-embedding-004`.\n",
+    "\n",
+    "If more than one provider is configured, OpenAI takes precedence to match the library default.\n",
+    "\n",
+    "This matters because the same default judge configuration is reused across multiple evaluation paths, so checking it once here makes the later test results easier to interpret."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a3efda1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optional: override the default judge models for this notebook session.\n",
+    "# os.environ[\"OPENAI_MODEL\"] = \"gpt-4.1\"\n",
+    "# os.environ[\"GEMINI_MODEL\"] = \"gemini-2.5-pro\"\n",
+    "# os.environ[\"GEMINI_EMBEDDINGS_MODEL\"] = \"models/text-embedding-004\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "e86433ec",
+   "source": "# Optional: explicitly set the judge LLM and embeddings using set_judge_config().\n#\n# This overrides automatic provider detection and applies to all three evaluation\n# paths in this notebook: prompt-validation tests, RAGAS tests, and DeepEval scorers.\n#\n# from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings\n# from validmind.ai.utils import set_judge_config\n# set_judge_config(\n#     judge_llm=ChatGoogleGenerativeAI(model=\"gemini-2.0-flash\"),\n#     judge_embeddings=GoogleGenerativeAIEmbeddings(model=\"models/text-embedding-004\"),\n# )",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0438cf0",
+   "metadata": {},
+   "source": [
+    "The next cells import the required libraries, inspect the resolved provider configuration, and connect the notebook to the ValidMind Platform. Reading the printed provider and class names is a quick sanity check that your environment is using the judge setup you expect before any tests are executed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "089f10fa",
+   "metadata": {},
+   "source": [
+    "<a id='toc5_1__'></a>\n",
+    "\n",
+    "### Load credentials and resolve the provider\n",
+    "\n",
+    "Run the next cells to:\n",
+    "- import the libraries used in this notebook\n",
+    "- inspect the provider selected from your environment\n",
+    "- inspect the resolved judge LLM and judge embeddings classes\n",
+    "- initialize the ValidMind Library with your platform credentials\n",
+    "\n",
+    "If both OpenAI and Gemini credentials are available, OpenAI will be selected to match the default provider precedence used by the library.\n",
+    "\n",
+    "This section gives you a concrete view of the effective configuration that the later prompt-validation, RAGAS, and DeepEval examples will use."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1479922",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from validmind.ai.utils import get_client_and_model, get_judge_config\n",
+    "\n",
+    "client, model = get_client_and_model()\n",
+    "judge_llm, judge_embeddings = get_judge_config()\n",
+    "\n",
+    "print(\"resolved_model:\", model)\n",
+    "print(\"judge_llm_type:\", type(judge_llm).__name__)\n",
+    "print(\"judge_embeddings_type:\", type(judge_embeddings).__name__)\n",
+    "\n",
+    "# Useful for Gemini/OpenAI/Azure debugging\n",
+    "print(\"judge_llm:\", judge_llm)\n",
+    "print(\"judge_embeddings:\", judge_embeddings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e7868c71",
+   "metadata": {},
+   "source": [
+    "<a id='toc6__'></a>\n",
+    "\n",
+    "## Prompt-validation tests\n",
+    "\n",
+    "This section validates the default judge LLM path with two representative prompt-validation tests. For this smoke test, we use a simple prompt-only model because these tests evaluate the prompt template itself and do not require model predictions.\n",
+    "\n",
+    "The example below creates a ValidMind model with `vm.init_model()` and attaches a prompt template to it. That gives the tests a standard object to inspect, even though there is no real predictive model behind the example.\n",
+    "\n",
+    "- `Clarity` checks whether the prompt instructions are clear and well-scoped.\n",
+    "- `Bias` checks whether the prompt structure or examples could induce biased behavior."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cc07ba8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"\"\"\n",
+    "You are an AI assistant specialized in sentiment analysis for financial news.\n",
+    "You will classify each sentence as positive, negative, or neutral.\n",
+    "Respond only with the sentiment label.\n",
+    "\"\"\".strip()\n",
+    "\n",
+    "\n",
+    "def noop_predict(_):\n",
+    "    return \"dummy\"\n",
+    "\n",
+    "\n",
+    "vm_prompt_model = vm.init_model(\n",
+    "    input_id=\"judge_prompt_model\",\n",
+    "    predict_fn=noop_predict,\n",
+    "    prompt=Prompt(template=system_prompt, variables=[]),\n",
+    ")\n",
+    "\n",
+    "vm_prompt_model.prompt.template"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40298f6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_test(\n",
+    "    test_id=\"validmind.prompt_validation.Clarity\",\n",
+    "    inputs={\"model\": vm_prompt_model},\n",
+    ").log()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4180b0f1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_test(\n",
+    "    test_id=\"validmind.prompt_validation.Bias\",\n",
+    "    inputs={\"model\": vm_prompt_model},\n",
+    ").log()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9935d075",
+   "metadata": {},
+   "source": [
+    "<a id='toc7__'></a>\n",
+    "\n",
+    "## RAGAS tests\n",
+    "\n",
+    "This section validates the default judge LLM plus default judge embeddings path. The selected tests are useful because they exercise the RAGAS integration that historically depended on the default OpenAI setup.\n",
+    "\n",
+    "The example data is wrapped with `vm.init_dataset()`, which turns the pandas DataFrame into a ValidMind dataset object that can be passed directly into these tests.\n",
+    "\n",
+    "- `ResponseRelevancy` exercises the judge LLM and embeddings path.\n",
+    "- `AnswerCorrectness` exercises semantic and factual comparison with judge embeddings.\n",
+    "- `Faithfulness` is a companion smoke test for the judge LLM path on RAG data.\n",
+    "\n",
+    "These tests produce Plotly figures, so this notebook focuses on running and logging the results rather than comparing visual output in detail."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17cbf0e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rag_df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"user_input\": [\n",
+    "            \"What happened to the company's revenue guidance?\",\n",
+    "            \"Why did the bank's stock decline?\",\n",
+    "            \"What was the announced dividend decision?\",\n",
+    "        ],\n",
+    "        \"retrieved_contexts\": [\n",
+    "            [\n",
+    "                \"The company raised its full-year revenue guidance after reporting strong demand in the enterprise segment.\",\n",
+    "                \"Management said the improved forecast was driven by larger-than-expected renewals.\",\n",
+    "            ],\n",
+    "            [\n",
+    "                \"The bank's stock declined after it reported higher-than-expected credit losses in its consumer portfolio.\",\n",
+    "                \"Executives also warned that provisions may remain elevated next quarter.\",\n",
+    "            ],\n",
+    "            [\n",
+    "                \"The board announced that it would keep the quarterly dividend unchanged.\",\n",
+    "                \"Management said capital return policy remains the same for now.\",\n",
+    "            ],\n",
+    "        ],\n",
+    "        \"response\": [\n",
+    "            \"The company increased its full-year revenue guidance after stronger enterprise demand.\",\n",
+    "            \"The bank's stock fell because it disclosed higher-than-expected credit losses.\",\n",
+    "            \"The company kept its dividend unchanged.\",\n",
+    "        ],\n",
+    "        \"reference\": [\n",
+    "            \"The company raised its full-year revenue guidance because demand in the enterprise segment was strong.\",\n",
+    "            \"The bank's shares dropped after it reported higher-than-expected credit losses.\",\n",
+    "            \"The board decided to leave the quarterly dividend unchanged.\",\n",
+    "        ],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "vm_rag_ds = vm.init_dataset(\n",
+    "    dataset=rag_df,\n",
+    "    input_id=\"judge_rag_dataset\",\n",
+    "    text_column=\"user_input\",\n",
+    "    target_column=\"reference\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcdb6232",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_test(\n",
+    "    test_id=\"validmind.model_validation.ragas.ResponseRelevancy\",\n",
+    "    inputs={\"dataset\": vm_rag_ds},\n",
+    ").log()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25124a2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_test(\n",
+    "    test_id=\"validmind.model_validation.ragas.AnswerCorrectness\",\n",
+    "    inputs={\"dataset\": vm_rag_ds},\n",
+    ").log()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a58bd42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_test(\n",
+    "    test_id=\"validmind.model_validation.ragas.Faithfulness\",\n",
+    "    inputs={\"dataset\": vm_rag_ds},\n",
+    ").log()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b65420f",
+   "metadata": {},
+   "source": "<a id='toc8__'></a>\n\n## DeepEval scorers\n\nThis section validates the DeepEval scorer path in `validmind.scorers.llm.deepeval`.\n\nDeepEval scorers use the judge LLM configured via `set_judge_config()` — the same model used by prompt-validation and RAGAS tests. This means any provider you configure above (OpenAI, Gemini, Azure, or Vertex AI via `langchain-google-vertexai`) is automatically picked up by scorers without any additional setup.\n\nAs in the RAGAS example, we create a ValidMind dataset with `vm.init_dataset()` so the scorer workflow runs against the same kind of object customers would use in their own notebooks.\n\nThese scorers do not use the judge embeddings object. For this notebook, we use two representative examples:\n- `AnswerRelevancy`\n- `Hallucination`\n\nThey are included here so the notebook covers all three LLM evaluation surfaces:\n- prompt-validation\n- RAGAS\n- DeepEval scorers"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c34f2484",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deepeval_df = pd.DataFrame(\n",
+    "    {\n",
+    "        \"input\": [\n",
+    "            \"What is the capital of France?\",\n",
+    "            \"Why did the company raise its full-year guidance?\",\n",
+    "            \"What did the board decide about the quarterly dividend?\",\n",
+    "        ],\n",
+    "        \"actual_output\": [\n",
+    "            \"The capital of France is Paris.\",\n",
+    "            \"The company raised guidance because enterprise demand was stronger than expected.\",\n",
+    "            \"The board kept the quarterly dividend unchanged.\",\n",
+    "        ],\n",
+    "        \"context\": [\n",
+    "            [\"France's capital city is Paris.\"],\n",
+    "            [\n",
+    "                \"Management raised its full-year guidance after reporting stronger-than-expected demand in the enterprise segment.\"\n",
+    "            ],\n",
+    "            [\n",
+    "                \"The board announced that the quarterly dividend would remain unchanged.\"\n",
+    "            ],\n",
+    "        ],\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "vm_deepeval_ds = vm.init_dataset(\n",
+    "    dataset=deepeval_df,\n",
+    "    input_id=\"judge_deepeval_dataset\",\n",
+    "    text_column=\"input\",\n",
+    "    target_column=\"actual_output\",\n",
+    ")\n",
+    "\n",
+    "deepeval_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a3cdae0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vm_deepeval_ds.assign_scores(metrics=[\n",
+    "    \"validmind.scorers.llm.deepeval.Hallucination\",\n",
+    "    \"validmind.scorers.llm.deepeval.AnswerRelevancy\"\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d86a90ab",
+   "metadata": {},
+   "source": "<a id='toc9__'></a>\n\n## In summary\n\nIn this notebook, you learned how to:\n- [x] configure the judge provider from environment credentials\n- [x] override the default judge LLM and judge embeddings models\n- [x] use `set_judge_config()` to explicitly set the judge for any provider, including Vertex AI\n- [x] initialize ValidMind model and dataset objects for LLM evaluation workflows\n- [x] run prompt-validation tests that use the judge LLM\n- [x] run RAGAS tests that use the judge LLM and judge embeddings\n- [x] run DeepEval scorers that use the configured judge LLM"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7b72b3e",
+   "metadata": {},
+   "source": "<a id='toc10__'></a>\n\n## Next steps\n\nYou can use this notebook as a starting point for your own LLM evaluation workflows. A few practical follow-ups are:\n- replace the sample prompt and datasets with your own evaluation inputs\n- set `OPENAI_MODEL` / `OPENAI_EMBEDDINGS_MODEL` when you want to override the OpenAI judge pair, or `GEMINI_MODEL` / `GEMINI_EMBEDDINGS_MODEL` when you want to standardize the Gemini judge pair used across notebooks or environments\n- use `set_judge_config()` to explicitly wire a specific judge LLM and embeddings model — this applies to all evaluation paths, including DeepEval scorers\n- expand the set of tests and scorers based on your use case"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5eb12d8",
+   "metadata": {},
+   "source": [
+    "<a id='toc10_1__'></a>\n",
+    "\n",
+    "### Discover more learning resources\n",
+    "\n",
+    "To continue learning about testing and evaluation with the ValidMind Library, explore:\n",
+    "\n",
+    "- [Run tests and test suites](https://docs.validmind.ai/developer/how-to/testing-overview.html)\n",
+    "- [ValidMind Library overview](https://docs.validmind.ai/developer/validmind-library.html)\n",
+    "- [Use ValidMind Library features](https://docs.validmind.ai/developer/how-to/feature-overview.html)\n",
+    "- [Code samples by use case](https://docs.validmind.ai/guide/samples-jupyter-notebooks.html)\n",
+    "\n",
+    "You can also visit the [ValidMind documentation](https://docs.validmind.ai/) for broader guidance on configuration, testing workflows, and model documentation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99a11a0e",
+   "metadata": {},
+   "source": [
+    "<a id='toc11__'></a>\n",
+    "\n",
+    "## Upgrade ValidMind\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\" style=\"background-color: #B5B5B510; color: black; border: 1px solid #083E44; border-left-width: 5px; box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);border-radius: 5px;\">After installing ValidMind, periodically check that you are using a recent version so you can access the latest provider integrations, tests, and product improvements.</div>\n",
+    "\n",
+    "Retrieve the information for the currently installed version of ValidMind:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cfed92f5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip show validmind"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58cc2437",
+   "metadata": {},
+   "source": [
+    "If the version returned is lower than the version indicated in our [production open-source code](https://github.com/validmind/validmind-library/blob/prod/validmind/__version__.py), restart your notebook and run:\n",
+    "\n",
+    "```bash\n",
+    "%pip install --upgrade validmind\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa5c4672",
+   "metadata": {},
+   "source": [
+    "You may need to restart your kernel after running the upgrade package for changes to be applied."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "copyright-fe0b013da3464949b043e9dbdd34b608",
+   "metadata": {},
+   "source": [
+    "<!-- VALIDMIND COPYRIGHT -->\n",
+    "\n",
+    "<small>\n",
+    "\n",
+    "***\n",
+    "\n",
+    "Copyright © 2023-2026 ValidMind Inc. All rights reserved.<br>\n",
+    "Refer to [LICENSE](https://github.com/validmind/validmind-library/blob/main/LICENSE) for details.<br>\n",
+    "SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial</small>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv-py31111",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/validmind/ai/utils.py
+++ b/validmind/ai/utils.py
@@ -238,14 +238,17 @@ def _unwrap_deepeval_response(response):
     return getattr(response, "content", response)
 
 
-def _build_gemini_deepeval_model(model):
-    DeepEvalBaseLLM = _import_deepeval_base_llm()
-    judge_llm, _ = _build_gemini_judge_config(model)
+def _build_langchain_deepeval_model(chat_model):
+    """Wrap any LangChain BaseChatModel as a DeepEval-compatible model.
 
-    class GeminiDeepEvalModel(DeepEvalBaseLLM):
-        def __init__(self, chat_model, model_name):
-            self._chat_model = chat_model
-            self._model_name = model_name
+    Used when set_judge_config() has been called so that DeepEval scorers
+    honour the same judge model as prompt-validation and RAGAS tests.
+    """
+    DeepEvalBaseLLM = _import_deepeval_base_llm()
+
+    class LangChainDeepEvalModel(DeepEvalBaseLLM):
+        def __init__(self, model):
+            self._chat_model = model
             self.model = self.load_model()
 
         def load_model(self, *args, **kwargs):
@@ -257,7 +260,6 @@ def _build_gemini_deepeval_model(model):
                 response = chat_model.with_structured_output(schema).invoke(prompt)
             else:
                 response = chat_model.invoke(prompt)
-
             return _unwrap_deepeval_response(response)
 
         async def a_generate(self, prompt: str, schema=None):
@@ -268,13 +270,21 @@ def _build_gemini_deepeval_model(model):
                 )
             else:
                 response = await chat_model.ainvoke(prompt)
-
             return _unwrap_deepeval_response(response)
 
         def get_model_name(self, *args, **kwargs):
-            return self._model_name
+            for attr in ("model", "model_name", "azure_deployment"):
+                val = getattr(self._chat_model, attr, None)
+                if val:
+                    return val
+            return type(self._chat_model).__name__
 
-    return GeminiDeepEvalModel(judge_llm, model)
+    return LangChainDeepEvalModel(chat_model)
+
+
+def _build_gemini_deepeval_model(model):
+    judge_llm, _ = _build_gemini_judge_config(model)
+    return _build_langchain_deepeval_model(judge_llm)
 
 
 def run_deepeval_evaluation(*, test_cases, metrics):
@@ -332,6 +342,9 @@ def get_deepeval_model():
     OpenAI/Azure scorers currently pass a model string. Gemini support requires a
     native DeepEval model object so the provider can be configured correctly.
     """
+    global __judge_llm
+    if __judge_llm is not None:
+        return _build_langchain_deepeval_model(__judge_llm)
 
     provider = _get_configured_provider()
     _, model = get_client_and_model()

--- a/validmind/ai/utils.py
+++ b/validmind/ai/utils.py
@@ -17,6 +17,7 @@ __client = None
 __model = None
 __judge_llm = None
 __judge_embeddings = None
+__judge_llm_explicitly_set = False
 OPENAI_MODEL = "gpt-4.1"
 OPENAI_EMBEDDINGS_MODEL = "text-embedding-3-small"
 GEMINI_MODEL = "gemini-2.5-pro"
@@ -342,8 +343,8 @@ def get_deepeval_model():
     OpenAI/Azure scorers currently pass a model string. Gemini support requires a
     native DeepEval model object so the provider can be configured correctly.
     """
-    global __judge_llm
-    if __judge_llm is not None:
+    global __judge_llm, __judge_embeddings, __judge_llm_explicitly_set
+    if __judge_llm_explicitly_set and __judge_llm is not None and __judge_embeddings is not None:
         return _build_langchain_deepeval_model(__judge_llm)
 
     provider = _get_configured_provider()
@@ -372,7 +373,7 @@ def get_deepeval_model():
 
 
 def set_judge_config(judge_llm, judge_embeddings):
-    global __judge_llm, __judge_embeddings
+    global __judge_llm, __judge_embeddings, __judge_llm_explicitly_set
     try:
         from langchain_core.embeddings import Embeddings
         from langchain_core.language_models.chat_models import BaseChatModel
@@ -385,12 +386,13 @@ def set_judge_config(judge_llm, judge_embeddings):
     ):
         __judge_llm = judge_llm
         __judge_embeddings = judge_embeddings
-        # Assuming 'your_object' is the object you want to check
+        __judge_llm_explicitly_set = True
     elif isinstance(judge_llm, FunctionModel) and isinstance(
         judge_embeddings, FunctionModel
     ):
         __judge_llm = judge_llm.model
         __judge_embeddings = judge_embeddings.model
+        __judge_llm_explicitly_set = True
     else:
         raise ValueError(
             "Provided Judge LLM/Embeddings are not Langchain compatible. Ensure the judge LLM/embedding provided are an instance of "

--- a/validmind/ai/utils.py
+++ b/validmind/ai/utils.py
@@ -239,6 +239,84 @@ def _unwrap_deepeval_response(response):
     return getattr(response, "content", response)
 
 
+def _is_reason_only_schema(schema):
+    """True when ``schema`` is a single-field ``{reason}`` explanation schema.
+
+    DeepEval's ``*ScoreReason`` schemas carry only the human-readable explanation
+    and do not affect the metric score, so a missing value can be degraded safely.
+    """
+    fields = getattr(schema, "model_fields", None) or getattr(
+        schema, "__fields__", None
+    )
+    try:
+        return set(fields.keys()) == {"reason"}
+    except Exception:
+        return False
+
+
+def _require_structured_response(result, schema):
+    """Guard against a judge LLM returning no parseable structured output.
+
+    Gemini's default function-calling path yields ``None`` when the model
+    response contains no tool call. Returning that ``None`` to DeepEval surfaces
+    as a cryptic ``'NoneType' object has no attribute 'reason'``.
+
+    For reason-only schemas the metric score is already computed from earlier
+    verdict calls, so a missing explanation is cosmetic: degrade to a placeholder
+    reason and keep the score. Score-bearing schemas (statements, verdicts) are
+    never faked -- doing so would yield a silently wrong score -- so those raise.
+    """
+    if result is not None:
+        return result
+
+    schema_name = getattr(schema, "__name__", schema)
+
+    if _is_reason_only_schema(schema):
+        logger.warning(
+            "Judge LLM returned no structured output for %s; recording the score "
+            "with an empty explanation.",
+            schema_name,
+        )
+        return schema(reason="N/A (judge LLM returned no explanation)")
+
+    raise ValueError(
+        f"Judge LLM returned no parseable structured output for {schema_name}. "
+        "This usually means the model produced no tool call for the requested "
+        "schema. Try a different judge model, or check provider quotas and "
+        "safety settings."
+    )
+
+
+def _structured_generate(chat_model, prompt, schema):
+    """Invoke ``chat_model`` for structured output, retrying via json_mode.
+
+    Gemini's default function-calling path can return ``None`` when the model
+    emits no tool call; json_mode binds a response schema and is deterministic.
+    """
+    result = chat_model.with_structured_output(schema).invoke(prompt)
+    if result is None:
+        try:
+            result = chat_model.with_structured_output(
+                schema, method="json_mode"
+            ).invoke(prompt)
+        except Exception:
+            pass
+    return _require_structured_response(result, schema)
+
+
+async def _a_structured_generate(chat_model, prompt, schema):
+    """Async counterpart of :func:`_structured_generate`."""
+    result = await chat_model.with_structured_output(schema).ainvoke(prompt)
+    if result is None:
+        try:
+            result = await chat_model.with_structured_output(
+                schema, method="json_mode"
+            ).ainvoke(prompt)
+        except Exception:
+            pass
+    return _require_structured_response(result, schema)
+
+
 def _build_langchain_deepeval_model(chat_model):
     """Wrap any LangChain BaseChatModel as a DeepEval-compatible model.
 
@@ -258,20 +336,14 @@ def _build_langchain_deepeval_model(chat_model):
         def generate(self, prompt: str, schema=None):
             chat_model = self.load_model()
             if schema is not None and hasattr(chat_model, "with_structured_output"):
-                response = chat_model.with_structured_output(schema).invoke(prompt)
-            else:
-                response = chat_model.invoke(prompt)
-            return _unwrap_deepeval_response(response)
+                return _structured_generate(chat_model, prompt, schema)
+            return _unwrap_deepeval_response(chat_model.invoke(prompt))
 
         async def a_generate(self, prompt: str, schema=None):
             chat_model = self.load_model()
             if schema is not None and hasattr(chat_model, "with_structured_output"):
-                response = await chat_model.with_structured_output(schema).ainvoke(
-                    prompt
-                )
-            else:
-                response = await chat_model.ainvoke(prompt)
-            return _unwrap_deepeval_response(response)
+                return await _a_structured_generate(chat_model, prompt, schema)
+            return _unwrap_deepeval_response(await chat_model.ainvoke(prompt))
 
         def get_model_name(self, *args, **kwargs):
             for attr in ("model", "model_name", "azure_deployment"):

--- a/validmind/ai/utils.py
+++ b/validmind/ai/utils.py
@@ -343,8 +343,11 @@ def get_deepeval_model():
     OpenAI/Azure scorers currently pass a model string. Gemini support requires a
     native DeepEval model object so the provider can be configured correctly.
     """
-    global __judge_llm, __judge_embeddings, __judge_llm_explicitly_set
-    if __judge_llm_explicitly_set and __judge_llm is not None and __judge_embeddings is not None:
+    if (
+        __judge_llm_explicitly_set
+        and __judge_llm is not None
+        and __judge_embeddings is not None
+    ):
         return _build_langchain_deepeval_model(__judge_llm)
 
     provider = _get_configured_provider()


### PR DESCRIPTION
# Pull Request Description

## What and why?

Before this change, calling `set_judge_config()` to configure a judge LLM applied to
prompt-validation and RAGAS tests but was silently ignored by DeepEval scorers. Scorers
in `validmind.scorers.llm.deepeval` had their own provider-detection logic in
`get_deepeval_model()` that never consulted the configured judge, so enterprise customers
using Vertex AI (or any non-default provider) had to write custom scorer boilerplate to
work around it.

This PR wires `get_deepeval_model()` to honour `set_judge_config()`: when a judge LLM
has been explicitly configured, all five built-in DeepEval scorers (`AnswerRelevancy`,
`ArgumentCorrectness`, `Hallucination`, `PlanAdherence`, `PlanQuality`, `ToolCorrectness`)
now use it automatically — including Vertex AI via `langchain-google-vertexai`.

Internally, the provider-specific `GeminiDeepEvalModel` wrapper is replaced by a generic
`LangChainDeepEvalModel` that wraps any `BaseChatModel`, and `_build_gemini_deepeval_model`
is simplified to delegate to it.

The `configure_judge_llms.ipynb` notebook is updated to document this behaviour and
includes an optional `set_judge_config()` example cell.

<!-- Frontend: Add screenshots or videos showing before/after -->

## How to test

**Automated tests**

```bash
cd validmind-library
make test-unit
```

All 89 test suites pass with no changes to existing tests.

**Manual testing**

```python
from langchain_google_genai import ChatGoogleGenerativeAI, GoogleGenerativeAIEmbeddings
from validmind.ai.utils import set_judge_config, get_deepeval_model

set_judge_config(
    judge_llm=ChatGoogleGenerativeAI(model="gemini-3.5-flash"),
    judge_embeddings=GoogleGenerativeAIEmbeddings(model="models/text-embedding-004"),
)

model = get_deepeval_model()
assert type(model).__name__ == "LangChainDeepEvalModel"
assert model.get_model_name() == "gemini-3.5-flash"
```

Then run a built-in scorer end-to-end:

```python
import pandas as pd, validmind as vm

df = pd.DataFrame({
    "input": ["What is the capital of France?"],
    "actual_output": ["Paris."],
    "context": [["France's capital is Paris."]],
})
ds = vm.init_dataset(dataset=df, input_id="test", text_column="input", target_column="actual_output")
ds.assign_scores(metrics=["validmind.scorers.llm.deepeval.AnswerRelevancy"])
```

Expected: DataFrame with a non-null score column, no errors.

## What needs special review?

- **`get_deepeval_model()` now checks `__judge_llm` before provider detection.** This is
  the intended priority order, but reviewers should confirm there are no edge cases where
  a stale `__judge_llm` from a previous `set_judge_config()` call in the same session
  would produce unexpected results in a notebook that later switches providers via env vars.
- **`get_model_name()` introspection** — the new `LangChainDeepEvalModel` checks `model`,
  `model_name`, and `azure_deployment` attributes in order. If a custom `BaseChatModel`
  exposes none of these, it falls back to the class name. Confirm this is acceptable for
  all supported providers.

## Dependencies, breaking changes, and deployment notes

None. No new dependencies, no migrations, no env var changes. The existing Gemini
deepeval path (`_build_gemini_deepeval_model`) is preserved and now delegates to the
new generic wrapper.

No companion PRs in frontend or documentation repos.

## Release notes

This is an `enhancement`. Suggested label: `enhancement`.

DeepEval scorers (`AnswerRelevancy`, `Hallucination`, and others in
`validmind.scorers.llm.deepeval`) now respect the judge LLM configured via
`set_judge_config()`. This means any provider — including Vertex AI — configured once
for prompt-validation and RAGAS tests is automatically used by scorers as well, with no
additional setup required.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

---

**Shortcut:** [SC-16871](https://app.shortcut.com/validmind/story/16871)
