### PR TITLE
Library release automation MVP

### DIFF
--- a/.github/workflows/notify-library-release-notes.yaml
+++ b/.github/workflows/notify-library-release-notes.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   notify:
+    if: vars.RELEASE_AUTOMATION == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Filter pre-release tags

--- a/.github/workflows/notify-library-release-notes.yaml
+++ b/.github/workflows/notify-library-release-notes.yaml
@@ -1,0 +1,29 @@
+name: Notify library release notes
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Filter pre-release tags
+        id: filter
+        run: |
+          TAG="${{ github.ref_name }}"
+          if echo "$TAG" | grep -qE '-(rc|alpha|beta)'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Skipping pre-release tag $TAG"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dispatch to release-notes
+        if: steps.filter.outputs.skip != 'true'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.RELEASE_NOTES_GITHUB_TOKEN }}
+          repository: validmind/release-notes
+          event-type: library-release-notes
+          client-payload: '{"tag":"${{ github.ref_name }}"}'


### PR DESCRIPTION
# Pull Request Description





## What and why?

Adds triggers on `validmind/validmind-library` so stable semver releases dispatch the library release-notes workflow after pilot.

### notify-library-release-notes.yaml

- Listens on `v*` tag push when `RELEASE_AUTOMATION=true`
- Skips prerelease suffixes (`-rc`, `-alpha`, `-beta`)
- Dispatches `library-release-notes` to `validmind/release-notes` with the pushed tag in `client-payload`
- Patch and feature classification happens in release-notes discovery (`release_type_hint` from semver bump)

## How to test

n/a — Automatic release generation workflows will run when flags are turned on.

## What needs special review?

n/a

## Dependencies, breaking changes, and deployment notes

### Related epic PRs

1. [release-notes](https://github.com/validmind/release-notes/pull/91)
2. [documentation](https://github.com/validmind/documentation/pull/1373)
3. [skills](https://github.com/validmind/skills/pull/13)
4. [installation](https://github.com/validmind/installation/pull/231)

## Release notes



n/a

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [ ] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
