### PR TITLE
fix: WeakspotsDiagnosis crash on custom metrics subset

### DIFF
--- a/tests/unit_tests/model_validation/sklearn/test_WeakspotsDiagnosis.py
+++ b/tests/unit_tests/model_validation/sklearn/test_WeakspotsDiagnosis.py
@@ -186,6 +186,70 @@ class TestWeakspotsDiagnosisEndToEnd(unittest.TestCase):
         result = WeakspotsDiagnosis(datasets=[train, test], model=model)
         self.assertGreater(len(result[0]), 0)
 
+    def _all_positive_pair(self, name):
+        # Deterministic dataset for pass/fail scoping tests. Every feature slice
+        # is 2/3 positive and every row is predicted positive, so for each slice:
+        #   Accuracy = Precision = 0.667, Recall = 1.0, F1 = 0.8.
+        # With the default thresholds this fails only on Accuracy (< 0.75), while
+        # F1 (0.8) clears its 0.7 threshold. That makes an all-four pass/fail
+        # (False) disagree with an F1-only pass/fail (True), so the test tells
+        # correct scoping apart from mere crash avoidance.
+        n = 120
+        pattern = ([1, 1, 0] * (n // 3))[:n]
+        preds = [1] * n
+        train, model = _dataset_with_predictions(f"{name}_train", pattern, preds)
+        test, _ = _dataset_with_predictions(f"{name}_test", pattern, preds, model=model)
+        return train, test, model
+
+    def test_metrics_subset_without_thresholds_runs(self):
+        # Regression for sc-17267: a custom metrics dict that is a strict subset of
+        # the default metric names with no thresholds= previously raised
+        # "Unable to coerce to Series, length must be 1: given 4" because
+        # pass_thresholds still carried all four default keys.
+        train, test, model = self._all_positive_pair("subset_run")
+        result = WeakspotsDiagnosis(
+            datasets=[train, test],
+            model=model,
+            features_columns=["f1"],
+            metrics={"f1": skm.f1_score},
+        )
+        self.assertGreater(len(result[0]), 0)
+        self.assertIsInstance(result[-1], bool)
+
+    def test_metrics_subset_scopes_pass_fail_to_that_metric(self):
+        # The F1-only pass/fail must reflect only the F1 threshold. On this data
+        # the all-four default fails (Accuracy 0.667 < 0.75) while F1 (0.8) passes,
+        # so the two runs must disagree.
+        train, test, model = self._all_positive_pair("subset_scope")
+
+        default = WeakspotsDiagnosis(
+            datasets=[train, test], model=model, features_columns=["f1"]
+        )
+        f1_only = WeakspotsDiagnosis(
+            datasets=[train, test],
+            model=model,
+            features_columns=["f1"],
+            metrics={"f1": skm.f1_score},
+        )
+
+        self.assertFalse(default[-1])
+        self.assertTrue(f1_only[-1])
+
+    def test_metrics_subset_with_full_thresholds_runs(self):
+        # Supplying thresholds for metrics that are not computed must not raise:
+        # pass_columns narrows to the intersection with the requested metrics.
+        train, test, model = self._all_positive_pair("subset_full_thresh")
+        result = WeakspotsDiagnosis(
+            datasets=[train, test],
+            model=model,
+            features_columns=["f1"],
+            metrics={"f1": skm.f1_score},
+            thresholds={"accuracy": 0.9, "f1": 0.7},
+        )
+        # Only F1 (0.8 >= 0.7) is in scope, so the untriggered Accuracy threshold
+        # (0.9) must not fail the test.
+        self.assertTrue(result[-1])
+
     def test_standard_binary_matches_default_precision(self):
         # Backward compatibility: for {0, 1} the per-slice Precision values must be
         # identical to scikit-learn's default binary precision so existing reports

--- a/validmind/tests/model_validation/sklearn/WeakspotsDiagnosis.py
+++ b/validmind/tests/model_validation/sklearn/WeakspotsDiagnosis.py
@@ -335,11 +335,10 @@ def WeakspotsDiagnosis(
         # For simplicity, test has failed if any of the metrics is below the threshold. We will
         # rely on visual assessment for this test for now.
         pass_columns = [c for c in pass_thresholds if c in metrics]
-        if (
-            pass_columns
-            and not df[df[pass_columns].lt(pass_thresholds).any(axis=1)].empty
-        ):
-            passed = False
+        if pass_columns:
+            thresholds_subset = {c: pass_thresholds[c] for c in pass_columns}
+            if not df[df[pass_columns].lt(thresholds_subset).any(axis=1)].empty:
+                passed = False
         results_1 = pd.concat([results_1, pd.DataFrame(r1)])
         results_2 = pd.concat([results_2, pd.DataFrame(r2)])
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

`WeakspotsDiagnosis` raises `ValueError: Unable to coerce to Series, length must be 1: given 4` when called with a custom `metrics=` dict that's a strict subset of the default metric names (accuracy/precision/recall/f1) and no explicit `thresholds=`.

The pass/fail check narrows `pass_columns` to the metrics actually requested, but compares against `pass_thresholds`, which still carries all four default keys:

```python
pass_columns = [c for c in pass_thresholds if c in metrics]   # e.g. ["F1"]
df[pass_columns].lt(pass_thresholds)                          # pass_thresholds has 4 keys
```

`DataFrame.lt(dict)` requires the dict to match the DataFrame's column count in this usage, so a 1-column frame against a 4-key dict raises. Minimal standalone repro:

```python
import pandas as pd
df = pd.DataFrame({"F1": [0.9, 0.2]})
df[["F1"]].lt({"Accuracy": 0.75, "Precision": 0.5, "Recall": 0.5, "F1": 0.7})
# ValueError: Unable to coerce to Series, length must be 1: given 4
```

This is a plausible, unremarkable usage pattern (a caller who only cares about F1) rather than an edge case anyone would think to avoid — passing a matching `thresholds=` sidesteps it, but nothing signals that requirement.

Found as a side-effect of implementing [sc-17261](https://app.shortcut.com/validmind/story/17261) (the ZD-704/#534 follow-up); tracked separately as [sc-17267](https://app.shortcut.com/validmind/story/17267) since it's an independent bug, not tied to that customer ticket.

## What changed

Narrows `pass_thresholds` to `pass_columns` right before the comparison. `plot_thresholds` (used for chart reference lines) is untouched, so charts still show reference lines for every metric — only the pass/fail check is scoped to what was actually requested.

## How to test

```python
from validmind.tests.model_validation.sklearn.WeakspotsDiagnosis import WeakspotsDiagnosis
from sklearn.metrics import f1_score
# ... datasets/model set up ...
WeakspotsDiagnosis(datasets=[train_ds, test_ds], model=vm_model,
                   metrics={"f1": f1_score})   # no thresholds= — used to crash
```

The added test builds a case where the default (all-four-metric) run fails on Accuracy while an F1-only run passes on the same data — proving the fix actually scopes pass/fail correctly rather than just suppressing the crash. `pytest tests/unit_tests/model_validation/sklearn/test_WeakspotsDiagnosis.py -q` → 15 passed.

## What needs special review?

The distinguishing test relies on binary data where F1 ≥ 0.7 mathematically forces precision/recall above their own 0.5 thresholds, so Accuracy is the only metric that can independently fail — worth a glance to confirm that reasoning holds.

## Dependencies, breaking changes, and deployment notes

None. Default (all-metrics) and full-thresholds-supplied paths are unaffected — this only changes behavior for the previously-crashing subset-without-matching-thresholds case.

## Release notes

Fixed `WeakspotsDiagnosis` raising `ValueError: Unable to coerce to Series, length must be 1: given 4` when called with a custom `metrics=` subset and no matching `thresholds=`.

## Checklist
- [x] What and why
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied
- [ ] PR linked to Shortcut
- [x] Unit tests added
- [x] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

Closes [sc-17267](https://app.shortcut.com/validmind/story/17267)

🤖 Generated with [Claude Code](https://claude.com/claude-code)