### PR TITLE
[SC-17529] Treat broken torch installs as "not a PyTorch model"

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,55 @@
+# Copyright © 2023-2026 ValidMind Inc. All rights reserved.
+# Refer to the LICENSE file in the root of this repository for details.
+# SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
+
+"""
+Unit tests for model type detection in validmind.vm_models.model
+"""
+
+import sys
+import unittest
+
+from sklearn.linear_model import LogisticRegression
+
+from validmind.vm_models.model import is_pytorch_model
+
+
+class BrokenTorchFinder:
+    """Simulates a broken torch install where importing torch raises an
+    error other than ImportError (e.g. OSError WinError 1114 when c10.dll
+    fails to load on Windows)."""
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "torch" or fullname.startswith("torch."):
+            raise OSError(
+                "[WinError 1114] A dynamic link library (DLL) initialization "
+                "routine failed. Error loading c10.dll"
+            )
+        return None
+
+
+class TestIsPyTorchModel(unittest.TestCase):
+    def test_non_torch_model_returns_false(self):
+        self.assertFalse(is_pytorch_model(LogisticRegression()))
+
+    def test_broken_torch_install_returns_false(self):
+        saved_modules = {
+            name: module
+            for name, module in sys.modules.items()
+            if name == "torch" or name.startswith("torch.")
+        }
+        for name in saved_modules:
+            del sys.modules[name]
+
+        finder = BrokenTorchFinder()
+        sys.meta_path.insert(0, finder)
+
+        try:
+            self.assertFalse(is_pytorch_model(LogisticRegression()))
+        finally:
+            sys.meta_path.remove(finder)
+            sys.modules.update(saved_modules)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validmind/vm_models/model.py
+++ b/validmind/vm_models/model.py
@@ -187,10 +187,12 @@ def is_pytorch_model(model):
     Checks if the model is a PyTorch model. Need to extend this
     method to check for all ways a PyTorch model can be created
     """
-    # if we can't import torch, then it's not a PyTorch model
+    # if we can't import torch, then it's not a PyTorch model. Broken torch
+    # installs can fail with errors other than ImportError (e.g. OSError
+    # WinError 1114 when a native DLL fails to load on Windows)
     try:
         import torch.nn as nn
-    except ImportError:
+    except Exception:
         return False
 
     # return False


### PR DESCRIPTION
# Pull Request Description

## What and why?

[SC-17529](https://app.shortcut.com/validmind/story/17529) / ZD 741: a customer on Windows could not run `vm.init_model()` on a **scikit-learn** logistic regression because `is_pytorch_model()` crashed while probing for torch.

The probe only caught `ImportError`, but a broken torch install can fail with other errors — in the customer's case `OSError: [WinError 1114] A dynamic link library (DLL) initialization routine failed` while loading `c10.dll`. That error escaped the `except` and aborted model initialization for a model that doesn't even use torch.

Now any failure to import torch is treated as "not a PyTorch model", matching the existing broad-catch precedent for the optional torch import in `validmind/client.py`.

Note for the ZD ticket: the customer's torch install is still broken (missing VC++ redistributable / mixed wheels are typical causes) — this fix makes the library robust to it so sklearn workflows are unaffected.

## How to test

`make test ONLY=tests.test_model`

The new `test_broken_torch_install_returns_false` simulates the broken install by making torch's import raise `OSError` (WinError 1114) via a meta-path finder; it fails without the one-line fix and passes with it.

## What needs special review?

Nothing — one-line exception-handling change plus tests.

## Dependencies, breaking changes, and deployment notes

None.

## Release notes

Fixed an error where `vm.init_model()` could fail for non-PyTorch models (e.g. scikit-learn) when a broken PyTorch installation was present in the environment, such as a `WinError 1114` DLL initialization failure on Windows.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] Special review areas
- [x] Dependencies, breaking changes, deployment notes
- [x] Release notes + label

🤖 Generated with [Claude Code](https://claude.com/claude-code)